### PR TITLE
feat: allow changing page size in /queue command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added 
 - An optional `page-size` to `/queue` command 
+- Add `default-queue-page-size` setting
 
 ## [2.9.3] - 2024-08-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added 
-- An optional `pageSize` to `/queue` command 
+- An optional `page-size` to `/queue` command 
 
 ## [2.9.3] - 2024-08-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added 
+- An optional `pageSize` to `/queue` command 
+
 ## [2.9.3] - 2024-08-19
 
 ### Fixed

--- a/migrations/20240824215313_add_default_queue_page_size/migration.sql
+++ b/migrations/20240824215313_add_default_queue_page_size/migration.sql
@@ -1,0 +1,19 @@
+-- RedefineTables
+PRAGMA foreign_keys=OFF;
+CREATE TABLE "new_Setting" (
+    "guildId" TEXT NOT NULL PRIMARY KEY,
+    "playlistLimit" INTEGER NOT NULL DEFAULT 50,
+    "secondsToWaitAfterQueueEmpties" INTEGER NOT NULL DEFAULT 30,
+    "leaveIfNoListeners" BOOLEAN NOT NULL DEFAULT true,
+    "queueAddResponseEphemeral" BOOLEAN NOT NULL DEFAULT false,
+    "autoAnnounceNextSong" BOOLEAN NOT NULL DEFAULT false,
+    "defaultVolume" INTEGER NOT NULL DEFAULT 100,
+    "defaultQueuePageSize" INTEGER NOT NULL DEFAULT 10,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL
+);
+INSERT INTO "new_Setting" ("autoAnnounceNextSong", "createdAt", "defaultVolume", "guildId", "leaveIfNoListeners", "playlistLimit", "queueAddResponseEphemeral", "secondsToWaitAfterQueueEmpties", "updatedAt") SELECT "autoAnnounceNextSong", "createdAt", "defaultVolume", "guildId", "leaveIfNoListeners", "playlistLimit", "queueAddResponseEphemeral", "secondsToWaitAfterQueueEmpties", "updatedAt" FROM "Setting";
+DROP TABLE "Setting";
+ALTER TABLE "new_Setting" RENAME TO "Setting";
+PRAGMA foreign_key_check;
+PRAGMA foreign_keys=ON;

--- a/schema.prisma
+++ b/schema.prisma
@@ -31,6 +31,7 @@ model Setting {
   queueAddResponseEphemeral      Boolean  @default(false)
   autoAnnounceNextSong           Boolean  @default(false)
   defaultVolume                  Int      @default(100)
+  defaultQueuePageSize           Int      @default(10)
   createdAt                      DateTime @default(now())
   updatedAt                      DateTime @updatedAt
 }

--- a/src/commands/config.ts
+++ b/src/commands/config.ts
@@ -63,7 +63,7 @@ export default class implements Command {
         .setName('page-size')
         .setDescription('page size of the /queue command')
         .setMinValue(1)
-        .setMaxValue(50)
+        .setMaxValue(30)
         .setRequired(true)))
     .addSubcommand(subcommand => subcommand
       .setName('get')

--- a/src/commands/config.ts
+++ b/src/commands/config.ts
@@ -57,6 +57,15 @@ export default class implements Command {
         .setMaxValue(100)
         .setRequired(true)))
     .addSubcommand(subcommand => subcommand
+      .setName('set-default-queue-page-size')
+      .setDescription('set the default page size of the /queue command')
+      .addIntegerOption(option => option
+        .setName('page-size')
+        .setDescription('page size of the /queue command')
+        .setMinValue(1)
+        .setMaxValue(50)
+        .setRequired(true)))
+    .addSubcommand(subcommand => subcommand
       .setName('get')
       .setDescription('show all settings'));
 
@@ -171,6 +180,23 @@ export default class implements Command {
         break;
       }
 
+      case 'set-default-queue-page-size': {
+        const value = interaction.options.getInteger('page-size')!;
+
+        await prisma.setting.update({
+          where: {
+            guildId: interaction.guild!.id,
+          },
+          data: {
+            defaultQueuePageSize: value,
+          },
+        });
+
+        await interaction.reply('👍 default queue page size updated');
+
+        break;
+      }
+
       case 'get': {
         const embed = new EmbedBuilder().setTitle('Config');
 
@@ -185,6 +211,7 @@ export default class implements Command {
           'Auto announce next song in queue': config.autoAnnounceNextSong ? 'yes' : 'no',
           'Add to queue reponses show for requester only': config.autoAnnounceNextSong ? 'yes' : 'no',
           'Default Volume': config.defaultVolume,
+          'Default queue page size': config.defaultQueuePageSize,
         };
 
         let description = '';

--- a/src/commands/queue.ts
+++ b/src/commands/queue.ts
@@ -20,7 +20,7 @@ export default class implements Command {
       .setName('page-size')
       .setDescription('how many items to display per page [default: 10, max: 50]')
       .setMinValue(1)
-      .setMaxValue(50)
+      .setMaxValue(30)
       .setRequired(false));
 
   private readonly playerManager: PlayerManager;

--- a/src/commands/queue.ts
+++ b/src/commands/queue.ts
@@ -14,6 +14,10 @@ export default class implements Command {
     .addIntegerOption(option => option
       .setName('page')
       .setDescription('page of queue to show [default: 1]')
+      .setRequired(false))
+    .addIntegerOption(option => option
+      .setName('pageSize')
+      .setDescription('how many items to display per page [default: 10]')
       .setRequired(false));
 
   private readonly playerManager: PlayerManager;
@@ -25,7 +29,11 @@ export default class implements Command {
   public async execute(interaction: ChatInputCommandInteraction) {
     const player = this.playerManager.get(interaction.guild!.id);
 
-    const embed = buildQueueEmbed(player, interaction.options.getInteger('page') ?? 1);
+    const embed = buildQueueEmbed(
+      player,
+      interaction.options.getInteger('page') ?? 1,
+      interaction.options.getInteger('pageSize') ?? 10,
+    );
 
     await interaction.reply({embeds: [embed]});
   }

--- a/src/commands/queue.ts
+++ b/src/commands/queue.ts
@@ -16,7 +16,7 @@ export default class implements Command {
       .setDescription('page of queue to show [default: 1]')
       .setRequired(false))
     .addIntegerOption(option => option
-      .setName('pageSize')
+      .setName('page-size')
       .setDescription('how many items to display per page [default: 10]')
       .setRequired(false));
 
@@ -32,7 +32,7 @@ export default class implements Command {
     const embed = buildQueueEmbed(
       player,
       interaction.options.getInteger('page') ?? 1,
-      interaction.options.getInteger('pageSize') ?? 10,
+      interaction.options.getInteger('page-size') ?? 10,
     );
 
     await interaction.reply({embeds: [embed]});

--- a/src/utils/build-embed.ts
+++ b/src/utils/build-embed.ts
@@ -5,8 +5,6 @@ import getProgressBar from './get-progress-bar.js';
 import {prettyTime} from './time.js';
 import {truncate} from './string.js';
 
-const PAGE_SIZE = 10;
-
 const getMaxSongTitleLength = (title: string) => {
   // eslint-disable-next-line no-control-regex
   const nonASCII = /[^\x00-\x7F]+/;
@@ -77,7 +75,7 @@ export const buildPlayingMessageEmbed = (player: Player): EmbedBuilder => {
   return message;
 };
 
-export const buildQueueEmbed = (player: Player, page: number): EmbedBuilder => {
+export const buildQueueEmbed = (player: Player, page: number, pageSize: number): EmbedBuilder => {
   const currentlyPlaying = player.getCurrent();
 
   if (!currentlyPlaying) {
@@ -85,14 +83,14 @@ export const buildQueueEmbed = (player: Player, page: number): EmbedBuilder => {
   }
 
   const queueSize = player.queueSize();
-  const maxQueuePage = Math.ceil((queueSize + 1) / PAGE_SIZE);
+  const maxQueuePage = Math.ceil((queueSize + 1) / pageSize);
 
   if (page > maxQueuePage) {
     throw new Error('the queue isn\'t that big');
   }
 
-  const queuePageBegin = (page - 1) * PAGE_SIZE;
-  const queuePageEnd = queuePageBegin + PAGE_SIZE;
+  const queuePageBegin = (page - 1) * pageSize;
+  const queuePageEnd = queuePageBegin + pageSize;
   const queuedSongs = player
     .getQueue()
     .slice(queuePageBegin, queuePageEnd)


### PR DESCRIPTION
Closes #1039

- Adds an optional `page-size` option to the `/queue` command (min 1, max 50)
- Adds a new setting for the default queue page size

- [x] I updated the changelog
