### PR TITLE
feat: allow running without spotify

### DIFF
--- a/src/commands/play.ts
+++ b/src/commands/play.ts
@@ -1,7 +1,7 @@
 import {AutocompleteInteraction, ChatInputCommandInteraction} from 'discord.js';
 import {URL} from 'url';
 import {SlashCommandBuilder} from '@discordjs/builders';
-import {inject, injectable} from 'inversify';
+import {inject, injectable, optional} from 'inversify';
 import Spotify from 'spotify-web-api-node';
 import Command from './index.js';
 import {TYPES} from '../types.js';
@@ -36,12 +36,12 @@ export default class implements Command {
 
   public requiresVC = true;
 
-  private readonly spotify: Spotify;
+  private readonly spotify?: Spotify;
   private readonly cache: KeyValueCacheProvider;
   private readonly addQueryToQueue: AddQueryToQueue;
 
-  constructor(@inject(TYPES.ThirdParty) thirdParty: ThirdParty, @inject(TYPES.KeyValueCache) cache: KeyValueCacheProvider, @inject(TYPES.Services.AddQueryToQueue) addQueryToQueue: AddQueryToQueue) {
-    this.spotify = thirdParty.spotify;
+  constructor(@inject(TYPES.ThirdParty) @optional() thirdParty: ThirdParty, @inject(TYPES.KeyValueCache) cache: KeyValueCacheProvider, @inject(TYPES.Services.AddQueryToQueue) addQueryToQueue: AddQueryToQueue) {
+    this.spotify = thirdParty?.spotify;
     this.cache = cache;
     this.addQueryToQueue = addQueryToQueue;
   }

--- a/src/inversify.config.ts
+++ b/src/inversify.config.ts
@@ -57,11 +57,20 @@ container.bind<Client>(TYPES.Client).toConstantValue(new Client({intents}));
 // Managers
 container.bind<PlayerManager>(TYPES.Managers.Player).to(PlayerManager).inSingletonScope();
 
+// Config values
+container.bind(TYPES.Config).toConstantValue(new ConfigProvider());
+
 // Services
 container.bind<GetSongs>(TYPES.Services.GetSongs).to(GetSongs).inSingletonScope();
 container.bind<AddQueryToQueue>(TYPES.Services.AddQueryToQueue).to(AddQueryToQueue).inSingletonScope();
 container.bind<YoutubeAPI>(TYPES.Services.YoutubeAPI).to(YoutubeAPI).inSingletonScope();
-container.bind<SpotifyAPI>(TYPES.Services.SpotifyAPI).to(SpotifyAPI).inSingletonScope();
+
+// Only instanciate spotify dependencies if the Spotify client ID and secret are set
+const config = container.get<ConfigProvider>(TYPES.Config);
+if (config.SPOTIFY_CLIENT_ID !== '' && config.SPOTIFY_CLIENT_SECRET !== '') {
+  container.bind<SpotifyAPI>(TYPES.Services.SpotifyAPI).to(SpotifyAPI).inSingletonScope();
+  container.bind(TYPES.ThirdParty).to(ThirdParty);
+}
 
 // Commands
 [
@@ -91,12 +100,7 @@ container.bind<SpotifyAPI>(TYPES.Services.SpotifyAPI).to(SpotifyAPI).inSingleton
   container.bind<Command>(TYPES.Command).to(command).inSingletonScope();
 });
 
-// Config values
-container.bind(TYPES.Config).toConstantValue(new ConfigProvider());
-
 // Static libraries
-container.bind(TYPES.ThirdParty).to(ThirdParty);
-
 container.bind(TYPES.FileCache).to(FileCacheProvider);
 container.bind(TYPES.KeyValueCache).to(KeyValueCacheProvider);
 

--- a/src/services/add-query-to-queue.ts
+++ b/src/services/add-query-to-queue.ts
@@ -1,6 +1,5 @@
 /* eslint-disable complexity */
 import {ChatInputCommandInteraction, GuildMember} from 'discord.js';
-import {URL} from 'node:url';
 import {inject, injectable} from 'inversify';
 import shuffle from 'array-shuffle';
 import {TYPES} from '../types.js';
@@ -60,74 +59,7 @@ export default class AddQueryToQueue {
 
     await interaction.deferReply({ephemeral: queueAddResponseEphemeral});
 
-    let newSongs: SongMetadata[] = [];
-    let extraMsg = '';
-
-    // Test if it's a complete URL
-    try {
-      const url = new URL(query);
-
-      const YOUTUBE_HOSTS = [
-        'www.youtube.com',
-        'youtu.be',
-        'youtube.com',
-        'music.youtube.com',
-        'www.music.youtube.com',
-      ];
-
-      if (YOUTUBE_HOSTS.includes(url.host)) {
-        // YouTube source
-        if (url.searchParams.get('list')) {
-          // YouTube playlist
-          newSongs.push(...await this.getSongs.youtubePlaylist(url.searchParams.get('list')!, shouldSplitChapters));
-        } else {
-          const songs = await this.getSongs.youtubeVideo(url.href, shouldSplitChapters);
-
-          if (songs) {
-            newSongs.push(...songs);
-          } else {
-            throw new Error('that doesn\'t exist');
-          }
-        }
-      } else if (url.protocol === 'spotify:' || url.host === 'open.spotify.com') {
-        const [convertedSongs, nSongsNotFound, totalSongs] = await this.getSongs.spotifySource(query, playlistLimit, shouldSplitChapters);
-
-        if (totalSongs > playlistLimit) {
-          extraMsg = `a random sample of ${playlistLimit} songs was taken`;
-        }
-
-        if (totalSongs > playlistLimit && nSongsNotFound !== 0) {
-          extraMsg += ' and ';
-        }
-
-        if (nSongsNotFound !== 0) {
-          if (nSongsNotFound === 1) {
-            extraMsg += '1 song was not found';
-          } else {
-            extraMsg += `${nSongsNotFound.toString()} songs were not found`;
-          }
-        }
-
-        newSongs.push(...convertedSongs);
-      } else {
-        const song = await this.getSongs.httpLiveStream(query);
-
-        if (song) {
-          newSongs.push(song);
-        } else {
-          throw new Error('that doesn\'t exist');
-        }
-      }
-    } catch (_: unknown) {
-      // Not a URL, must search YouTube
-      const songs = await this.getSongs.youtubeVideoSearch(query, shouldSplitChapters);
-
-      if (songs) {
-        newSongs.push(...songs);
-      } else {
-        throw new Error('that doesn\'t exist');
-      }
-    }
+    let [newSongs, extraMsg] = await this.getSongs.getSongs(query, playlistLimit, shouldSplitChapters);
 
     if (newSongs.length === 0) {
       throw new Error('no songs found');

--- a/src/services/config.ts
+++ b/src/services/config.ts
@@ -12,8 +12,8 @@ export const DATA_DIR = path.resolve(process.env.DATA_DIR ? process.env.DATA_DIR
 const CONFIG_MAP = {
   DISCORD_TOKEN: process.env.DISCORD_TOKEN,
   YOUTUBE_API_KEY: process.env.YOUTUBE_API_KEY,
-  SPOTIFY_CLIENT_ID: process.env.SPOTIFY_CLIENT_ID,
-  SPOTIFY_CLIENT_SECRET: process.env.SPOTIFY_CLIENT_SECRET,
+  SPOTIFY_CLIENT_ID: process.env.SPOTIFY_CLIENT_ID ?? '',
+  SPOTIFY_CLIENT_SECRET: process.env.SPOTIFY_CLIENT_SECRET ?? '',
   REGISTER_COMMANDS_ON_BOT: process.env.REGISTER_COMMANDS_ON_BOT === 'true',
   DATA_DIR,
   CACHE_DIR: path.join(DATA_DIR, 'cache'),

--- a/src/services/get-songs.ts
+++ b/src/services/get-songs.ts
@@ -1,34 +1,120 @@
-import {inject, injectable} from 'inversify';
+import {inject, injectable, optional} from 'inversify';
 import * as spotifyURI from 'spotify-uri';
 import {SongMetadata, QueuedPlaylist, MediaSource} from './player.js';
 import {TYPES} from '../types.js';
 import ffmpeg from 'fluent-ffmpeg';
 import YoutubeAPI from './youtube-api.js';
 import SpotifyAPI, {SpotifyTrack} from './spotify-api.js';
+import {URL} from 'node:url';
 
 @injectable()
 export default class {
   private readonly youtubeAPI: YoutubeAPI;
-  private readonly spotifyAPI: SpotifyAPI;
+  private readonly spotifyAPI?: SpotifyAPI;
 
-  constructor(@inject(TYPES.Services.YoutubeAPI) youtubeAPI: YoutubeAPI, @inject(TYPES.Services.SpotifyAPI) spotifyAPI: SpotifyAPI) {
+  constructor(@inject(TYPES.Services.YoutubeAPI) youtubeAPI: YoutubeAPI, @inject(TYPES.Services.SpotifyAPI) @optional() spotifyAPI?: SpotifyAPI) {
     this.youtubeAPI = youtubeAPI;
     this.spotifyAPI = spotifyAPI;
   }
 
-  async youtubeVideoSearch(query: string, shouldSplitChapters: boolean): Promise<SongMetadata[]> {
+  async getSongs(query: string, playlistLimit: number, shouldSplitChapters: boolean): Promise<[SongMetadata[], string]> {
+    let newSongs: SongMetadata[] = [];
+    let extraMsg = '';
+
+    // Test if it's a complete URL
+    try {
+      const url = new URL(query);
+
+      const YOUTUBE_HOSTS = [
+        'www.youtube.com',
+        'youtu.be',
+        'youtube.com',
+        'music.youtube.com',
+        'www.music.youtube.com',
+      ];
+
+      if (YOUTUBE_HOSTS.includes(url.host)) {
+        // YouTube source
+        if (url.searchParams.get('list')) {
+          // YouTube playlist
+          newSongs.push(...await this.youtubePlaylist(url.searchParams.get('list')!, shouldSplitChapters));
+        } else {
+          const songs = await this.youtubeVideo(url.href, shouldSplitChapters);
+
+          if (songs) {
+            newSongs.push(...songs);
+          } else {
+            throw new Error('that doesn\'t exist');
+          }
+        }
+      } else if (url.protocol === 'spotify:' || url.host === 'open.spotify.com') {
+        if (this.spotifyAPI === undefined) {
+          throw new Error('Spotify is not enabled!')
+        }
+
+        const [convertedSongs, nSongsNotFound, totalSongs] = await this.spotifySource(query, playlistLimit, shouldSplitChapters);
+
+        if (totalSongs > playlistLimit) {
+          extraMsg = `a random sample of ${playlistLimit} songs was taken`;
+        }
+
+        if (totalSongs > playlistLimit && nSongsNotFound !== 0) {
+          extraMsg += ' and ';
+        }
+
+        if (nSongsNotFound !== 0) {
+          if (nSongsNotFound === 1) {
+            extraMsg += '1 song was not found';
+          } else {
+            extraMsg += `${nSongsNotFound.toString()} songs were not found`;
+          }
+        }
+
+        newSongs.push(...convertedSongs);
+      } else {
+        const song = await this.httpLiveStream(query);
+
+        if (song) {
+          newSongs.push(song);
+        } else {
+          throw new Error('that doesn\'t exist');
+        }
+      }
+    } catch (err: any) {
+      if (err = 'spotify not enabled') {
+        throw err;
+      }
+
+      // Not a URL, must search YouTube
+      const songs = await this.youtubeVideoSearch(query, shouldSplitChapters);
+
+      if (songs) {
+        newSongs.push(...songs);
+      } else {
+        throw new Error('that doesn\'t exist');
+      }
+    }
+
+    return [newSongs, extraMsg];
+  }
+
+  private async youtubeVideoSearch(query: string, shouldSplitChapters: boolean): Promise<SongMetadata[]> {
     return this.youtubeAPI.search(query, shouldSplitChapters);
   }
 
-  async youtubeVideo(url: string, shouldSplitChapters: boolean): Promise<SongMetadata[]> {
+  private async youtubeVideo(url: string, shouldSplitChapters: boolean): Promise<SongMetadata[]> {
     return this.youtubeAPI.getVideo(url, shouldSplitChapters);
   }
 
-  async youtubePlaylist(listId: string, shouldSplitChapters: boolean): Promise<SongMetadata[]> {
+  private async youtubePlaylist(listId: string, shouldSplitChapters: boolean): Promise<SongMetadata[]> {
     return this.youtubeAPI.getPlaylist(listId, shouldSplitChapters);
   }
 
-  async spotifySource(url: string, playlistLimit: number, shouldSplitChapters: boolean): Promise<[SongMetadata[], number, number]> {
+  private async spotifySource(url: string, playlistLimit: number, shouldSplitChapters: boolean): Promise<[SongMetadata[], number, number]> {
+    if (this.spotifyAPI === undefined) {
+      return [[], 0, 0]; 
+    }
+
     const parsed = spotifyURI.parse(url);
 
     switch (parsed.type) {
@@ -58,7 +144,7 @@ export default class {
     }
   }
 
-  async httpLiveStream(url: string): Promise<SongMetadata> {
+  private async httpLiveStream(url: string): Promise<SongMetadata> {
     return new Promise((resolve, reject) => {
       ffmpeg(url).ffprobe((err, _) => {
         if (err) {

--- a/src/services/get-songs.ts
+++ b/src/services/get-songs.ts
@@ -18,7 +18,7 @@ export default class {
   }
 
   async getSongs(query: string, playlistLimit: number, shouldSplitChapters: boolean): Promise<[SongMetadata[], string]> {
-    let newSongs: SongMetadata[] = [];
+    const newSongs: SongMetadata[] = [];
     let extraMsg = '';
 
     // Test if it's a complete URL
@@ -49,7 +49,7 @@ export default class {
         }
       } else if (url.protocol === 'spotify:' || url.host === 'open.spotify.com') {
         if (this.spotifyAPI === undefined) {
-          throw new Error('Spotify is not enabled!')
+          throw new Error('Spotify is not enabled!');
         }
 
         const [convertedSongs, nSongsNotFound, totalSongs] = await this.spotifySource(query, playlistLimit, shouldSplitChapters);
@@ -81,7 +81,7 @@ export default class {
         }
       }
     } catch (err: any) {
-      if (err = 'spotify not enabled') {
+      if (err instanceof Error && err.message === 'Spotify is not enabled!') {
         throw err;
       }
 
@@ -112,7 +112,7 @@ export default class {
 
   private async spotifySource(url: string, playlistLimit: number, shouldSplitChapters: boolean): Promise<[SongMetadata[], number, number]> {
     if (this.spotifyAPI === undefined) {
-      return [[], 0, 0]; 
+      return [[], 0, 0];
     }
 
     const parsed = spotifyURI.parse(url);

--- a/src/services/youtube-api.ts
+++ b/src/services/youtube-api.ts
@@ -95,7 +95,7 @@ export default class {
     }
 
     if (!firstVideo) {
-      throw new Error('No video found.');
+      return [];
     }
 
     return this.getVideo(firstVideo.url, shouldSplitChapters);

--- a/src/utils/get-youtube-and-spotify-suggestions-for.ts
+++ b/src/utils/get-youtube-and-spotify-suggestions-for.ts
@@ -15,12 +15,11 @@ const filterDuplicates = <T extends {name: string}>(items: T[]) => {
 };
 
 const getYouTubeAndSpotifySuggestionsFor = async (query: string, spotify?: SpotifyWebApi, limit = 10): Promise<APIApplicationCommandOptionChoice[]> => {
-  
   // Only search Spotify if enabled
-  let spotifySuggestionPromise = spotify !== undefined 
-    ? spotify.search(query, ['album', 'track'], {limit})
-    : undefined;
-    
+  const spotifySuggestionPromise = spotify === undefined
+    ? undefined
+    : spotify.search(query, ['album', 'track'], {limit});
+
   const youtubeSuggestions = await getYouTubeSuggestionsFor(query);
 
   const totalYouTubeResults = youtubeSuggestions.length;
@@ -36,11 +35,9 @@ const getYouTubeAndSpotifySuggestionsFor = async (query: string, spotify?: Spoti
         value: suggestion,
       }),
       ));
-  
-  
+
   if (spotify !== undefined && spotifySuggestionPromise !== undefined) {
-    
-    const spotifyResponse = (await spotifySuggestionPromise).body
+    const spotifyResponse = (await spotifySuggestionPromise).body;
     const spotifyAlbums = filterDuplicates(spotifyResponse.albums?.items ?? []);
     const spotifyTracks = filterDuplicates(spotifyResponse.tracks?.items ?? []);
 
@@ -51,14 +48,13 @@ const getYouTubeAndSpotifySuggestionsFor = async (query: string, spotify?: Spoti
     const maxSpotifySuggestions = Math.floor(limit / 2);
     const numOfSpotifySuggestions = Math.min(maxSpotifySuggestions, totalSpotifyResults);
 
-
     const maxSpotifyAlbums = Math.floor(numOfSpotifySuggestions / 2);
     const numOfSpotifyAlbums = Math.min(maxSpotifyAlbums, spotifyResponse.albums?.items.length ?? 0);
     const maxSpotifyTracks = numOfSpotifySuggestions - numOfSpotifyAlbums;
 
-    // make room for spotify results
+    // Make room for spotify results
     const maxYouTubeSuggestions = limit - numOfSpotifySuggestions;
-    suggestions = suggestions.slice(0, maxYouTubeSuggestions)
+    suggestions = suggestions.slice(0, maxYouTubeSuggestions);
 
     suggestions.push(
       ...spotifyAlbums.slice(0, maxSpotifyAlbums).map(album => ({
@@ -66,14 +62,13 @@ const getYouTubeAndSpotifySuggestionsFor = async (query: string, spotify?: Spoti
         value: `spotify:album:${album.id}`,
       })),
     );
-  
+
     suggestions.push(
       ...spotifyTracks.slice(0, maxSpotifyTracks).map(track => ({
         name: `Spotify: 🎵 ${track.name}${track.artists.length > 0 ? ` - ${track.artists[0].name}` : ''}`,
         value: `spotify:track:${track.id}`,
       })),
     );
-
   }
 
   return suggestions;

--- a/src/utils/get-youtube-and-spotify-suggestions-for.ts
+++ b/src/utils/get-youtube-and-spotify-suggestions-for.ts
@@ -14,28 +14,19 @@ const filterDuplicates = <T extends {name: string}>(items: T[]) => {
   return results;
 };
 
-const getYouTubeAndSpotifySuggestionsFor = async (query: string, spotify: SpotifyWebApi, limit = 10): Promise<APIApplicationCommandOptionChoice[]> => {
-  const [youtubeSuggestions, spotifyResults] = await Promise.all([
-    getYouTubeSuggestionsFor(query),
-    spotify.search(query, ['track', 'album'], {limit: 5}),
-  ]);
+const getYouTubeAndSpotifySuggestionsFor = async (query: string, spotify?: SpotifyWebApi, limit = 10): Promise<APIApplicationCommandOptionChoice[]> => {
+  
+  // Only search Spotify if enabled
+  let spotifySuggestionPromise = spotify !== undefined 
+    ? spotify.search(query, ['album', 'track'], {limit})
+    : undefined;
+    
+  const youtubeSuggestions = await getYouTubeSuggestionsFor(query);
 
   const totalYouTubeResults = youtubeSuggestions.length;
+  const numOfYouTubeSuggestions = Math.min(limit, totalYouTubeResults);
 
-  const spotifyAlbums = filterDuplicates(spotifyResults.body.albums?.items ?? []);
-  const spotifyTracks = filterDuplicates(spotifyResults.body.tracks?.items ?? []);
-
-  const totalSpotifyResults = spotifyAlbums.length + spotifyTracks.length;
-
-  // Number of results for each source should be roughly the same.
-  // If we don't have enough Spotify suggestions, prioritize YouTube results.
-  const maxSpotifySuggestions = Math.floor(limit / 2);
-  const numOfSpotifySuggestions = Math.min(maxSpotifySuggestions, totalSpotifyResults);
-
-  const maxYouTubeSuggestions = limit - numOfSpotifySuggestions;
-  const numOfYouTubeSuggestions = Math.min(maxYouTubeSuggestions, totalYouTubeResults);
-
-  const suggestions: APIApplicationCommandOptionChoice[] = [];
+  let suggestions: APIApplicationCommandOptionChoice[] = [];
 
   suggestions.push(
     ...youtubeSuggestions
@@ -45,24 +36,45 @@ const getYouTubeAndSpotifySuggestionsFor = async (query: string, spotify: Spotif
         value: suggestion,
       }),
       ));
+  
+  
+  if (spotify !== undefined && spotifySuggestionPromise !== undefined) {
+    
+    const spotifyResponse = (await spotifySuggestionPromise).body
+    const spotifyAlbums = filterDuplicates(spotifyResponse.albums?.items ?? []);
+    const spotifyTracks = filterDuplicates(spotifyResponse.tracks?.items ?? []);
 
-  const maxSpotifyAlbums = Math.floor(numOfSpotifySuggestions / 2);
-  const numOfSpotifyAlbums = Math.min(maxSpotifyAlbums, spotifyResults.body.albums?.items.length ?? 0);
-  const maxSpotifyTracks = numOfSpotifySuggestions - numOfSpotifyAlbums;
+    const totalSpotifyResults = spotifyAlbums.length + spotifyTracks.length;
 
-  suggestions.push(
-    ...spotifyAlbums.slice(0, maxSpotifyAlbums).map(album => ({
-      name: `Spotify: 💿 ${album.name}${album.artists.length > 0 ? ` - ${album.artists[0].name}` : ''}`,
-      value: `spotify:album:${album.id}`,
-    })),
-  );
+    // Number of results for each source should be roughly the same.
+    // If we don't have enough Spotify suggestions, prioritize YouTube results.
+    const maxSpotifySuggestions = Math.floor(limit / 2);
+    const numOfSpotifySuggestions = Math.min(maxSpotifySuggestions, totalSpotifyResults);
 
-  suggestions.push(
-    ...spotifyTracks.slice(0, maxSpotifyTracks).map(track => ({
-      name: `Spotify: 🎵 ${track.name}${track.artists.length > 0 ? ` - ${track.artists[0].name}` : ''}`,
-      value: `spotify:track:${track.id}`,
-    })),
-  );
+
+    const maxSpotifyAlbums = Math.floor(numOfSpotifySuggestions / 2);
+    const numOfSpotifyAlbums = Math.min(maxSpotifyAlbums, spotifyResponse.albums?.items.length ?? 0);
+    const maxSpotifyTracks = numOfSpotifySuggestions - numOfSpotifyAlbums;
+
+    // make room for spotify results
+    const maxYouTubeSuggestions = limit - numOfSpotifySuggestions;
+    suggestions = suggestions.slice(0, maxYouTubeSuggestions)
+
+    suggestions.push(
+      ...spotifyAlbums.slice(0, maxSpotifyAlbums).map(album => ({
+        name: `Spotify: 💿 ${album.name}${album.artists.length > 0 ? ` - ${album.artists[0].name}` : ''}`,
+        value: `spotify:album:${album.id}`,
+      })),
+    );
+  
+    suggestions.push(
+      ...spotifyTracks.slice(0, maxSpotifyTracks).map(track => ({
+        name: `Spotify: 🎵 ${track.name}${track.artists.length > 0 ? ` - ${track.artists[0].name}` : ''}`,
+        value: `spotify:track:${track.id}`,
+      })),
+    );
+
+  }
 
   return suggestions;
 };


### PR DESCRIPTION
Closes #835 

This PR allows muse to run without a Spotify client ID and secret.

The command will responde with `🚫 ope: Spotify is not enabled!` if a user tries to query a song with a Spotify URL.

### Logic changes

To allow for cases where Spotify isn't available two methods required changes.

__`addToQueue()`__: The logic for determining which source to fetch songs from has been moved to the `getSongs` service class in `get-songs.ts`.  Songs are fetched through a single method named `getSongs()` which include the old logic from `addToQueue()`, all other methods in the class has been made private.

__`getYouTubeAndSpotifySuggestionsFor()`__: Has been refactored, all Spotify logic has been moved to the end of the method (fetching still happens asynchrony at the beginning).

PR also updates `YoutubeAPI.search()` method to return an empty array if no match is found for the search query. This allows for better error handling other places in the code.

- [ ] I updated the changelog

