### PR TITLE
remove requirement for Spotify in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,11 +30,8 @@ Muse is a **highly-opinionated midwestern self-hosted** Discord music bot **that
 Muse is written in TypeScript. You can either run Muse with Docker (recommended) or directly with Node.js. Both methods require API keys passed in as environment variables:
 
 - `DISCORD_TOKEN` can be acquired [here](https://discordapp.com/developers/applications) by creating a 'New Application', then going to 'Bot'.
-- `SPOTIFY_CLIENT_ID` and `SPOTIFY_CLIENT_SECRET` can be acquired [here](https://developer.spotify.com/dashboard/applications) with 'Create a Client ID'.
+- `SPOTIFY_CLIENT_ID` and `SPOTIFY_CLIENT_SECRET` can be acquired [here](https://developer.spotify.com/dashboard/applications) with 'Create a Client ID' (Optional).
 - `YOUTUBE_API_KEY` can be acquired by [creating a new project](https://console.developers.google.com) in Google's Developer Console, enabling the YouTube API, and creating an API key under credentials.
-
-> [!WARNING]
-> Even if you don't plan on using Spotify, you must still provide the client ID and secret; otherwise Muse will not function.
 
 Muse will log a URL when run. Open this URL in a browser to invite Muse to your server. Muse will DM the server owner after it's added with setup instructions.
 
@@ -68,8 +65,6 @@ You can also store your tokens in an environment file and make it available to y
 **Docker Compose**:
 
 ```yaml
-version: '3.4'
-
 services:
   muse:
     image: ghcr.io/museofficial/muse:latest


### PR DESCRIPTION
Remove warning in readme stating that Spotify secret is required. Also removed version from docker compose example as is generally not needed and is not used by [official docker compose examples](https://docs.docker.com/get-started/workshop/08_using_compose/) either.


- [ ] I updated the changelog
