### PR TITLE
Fix volume issue when reducing volume during voice

### DIFF
--- a/src/services/player.ts
+++ b/src/services/player.ts
@@ -75,6 +75,7 @@ export default class {
   private audioResource: AudioResource | null = null;
   private volume?: number;
   private defaultVolume: number = DEFAULT_VOLUME;
+  private previousVolume: number = DEFAULT_VOLUME;
   private nowPlaying: QueuedSong | null = null;
   private playPositionInterval: NodeJS.Timeout | undefined;
   private lastSongURL = '';
@@ -364,7 +365,7 @@ export default class {
     if (speakingUsers && speakingUsers.size > 0) {
       this.setVolume(turnDownVolumeWhenPeopleSpeakTarget);
     } else {
-      this.setVolume(this.defaultVolume);
+      this.setVolume(this.previousVolume);
     }
   }
 
@@ -481,6 +482,7 @@ export default class {
 
   setVolume(level: number): void {
     // Level should be a number between 0 and 100 = 0% => 100%
+    this.previousVolume = this.volume ?? this.defaultVolume;
     this.volume = level;
     this.setAudioPlayerVolume(level);
   }


### PR DESCRIPTION
Fixes #1143

Add functionality to return to the previously set volume after reducing volume when someone speaks.

* Add a new variable `previousVolume` to store the previously set volume.
* Update the `setVolume` method to update the `previousVolume` variable whenever the volume is set.
* Update the `suppressVoiceWhenPeopleAreSpeaking` method to set the volume to `previousVolume` instead of `defaultVolume`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/museofficial/muse/pull/1147?shareId=77ab8e5f-e4bd-4126-a561-31fce6a77627).