### PR TITLE
Bump: @distube/ytdl-core to v4.16.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "@discordjs/opus": "^0.10.0",
     "@discordjs/rest": "1.0.1",
     "@discordjs/voice": "0.18.0",
-    "@distube/ytdl-core": "^4.16.6",
+    "@distube/ytdl-core": "^4.16.8",
     "@distube/ytsr": "^2.0.4",
     "@prisma/client": "4.16.0",
     "@types/libsodium-wrappers": "^0.7.9",


### PR DESCRIPTION
In the latest version, the issue has been resolved where starting an instance of ffmpeg caused the server to return a 403 Forbidden error (access denied), this preventing the playback of any music tracks.

