### PR TITLE
bump spotify-uri to 4.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- bumped spotify-uri, fixing links with localisation
 
 ## [2.11.1] - 2025-04-07
 - Revert Dockerfile to inherit dependencies image from base image

--- a/package.json
+++ b/package.json
@@ -123,7 +123,7 @@
     "read-pkg": "7.1.0",
     "reflect-metadata": "^0.2.2",
     "sponsorblock-api": "^0.2.4",
-    "spotify-uri": "^3.0.2",
+    "spotify-uri": "^4.1.0",
     "spotify-web-api-node": "^5.0.2",
     "sync-fetch": "^0.3.1",
     "tsx": "3.8.2",


### PR DESCRIPTION
Fixes links with localisation `intl-*` in the URL e.g. 
https://open.spotify.com/intl-pt/track/5F2lWCeBZMxpo6SG1Q3PlL 

- [x] I updated the changelog
