### PR TITLE
Fix ytdl-core VERSION

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "@discordjs/opus": "^0.10.0",
     "@discordjs/rest": "1.0.1",
     "@discordjs/voice": "0.18.0",
-    "@distube/ytdl-core": "^4.16.10",
+    "@distube/ytdl-core": "^4.16.12",
     "@distube/ytsr": "^2.0.4",
     "@prisma/client": "4.16.0",
     "@types/libsodium-wrappers": "^0.7.9",


### PR DESCRIPTION
### Summary

- Updates @distube/ytdl-core from v4.16.10 to v4.16.12
- Resolves YouTube player script parsing issues that were causing stream URL failures
- Fixes warnings about decipher function and n transform function parsing

### Problem

The bot was experiencing errors when trying to play YouTube content:

```
WARNING: Could not parse decipher function.
Stream URLs will be missing.
WARNING: Could not parse n transform function.
```
This was happening because YouTube changed their player scripts, breaking the decipher function parsing in the older version of ytdl-core.

### Solution
Updated @distube/ytdl-core to the latest version (4.16.12) which includes updated parsing logic to handle YouTube's recent changes.

### Testing
✅ Docker build passes successfully
✅ Bot functionality restored for YouTube content
### Dependencies
Updated @distube/ytdl-core from ^4.16.10 to ^4.16.12
No breaking changes or API modifications required