### PR TITLE
Fix silent FFmpeg playback failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Detect FFmpeg failures before reporting playback as started, skip failed queued tracks instead of wedging the player, and retain bounded failure details in the container log.
+- Log failed Discord interactions with command and guild context so playback incidents can be diagnosed after the fact.
+
 ## [2.11.6] - 2026-07-12
 
 - Add optional age-verified YouTube cookie-file support for age-restricted playback.

--- a/package.json
+++ b/package.json
@@ -122,6 +122,7 @@
     "parse-duration": "1.0.2",
     "patch-package": "^8.0.0",
     "postinstall-postinstall": "^2.1.0",
+    "prism-media": "^1.3.5",
     "read-pkg": "7.1.0",
     "reflect-metadata": "^0.2.2",
     "sponsorblock-api": "^0.2.4",

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -15,6 +15,24 @@ import {REST} from '@discordjs/rest';
 import {Routes} from 'discord-api-types/v10';
 import registerCommandsOnGuild from './utils/register-commands-on-guild.js';
 
+const sanitizeErrorDetail = (error: unknown) => {
+  const message = error instanceof Error ? error.message : String(error);
+  return message
+    .replace(/https?:\/\/\S+/gi, '[URL]')
+    .replace(/(["']?\b(?:api[-_]?key|key|token|authorization|cookie)["']?\s*[:=]\s*)(?:["'][^"']*["']|Bearer\s+[^,;\s]+|[^,;\s}\]]+)/gi, '$1[redacted]')
+    .replace(/\b(authorization|cookie)\s*[:=]\s*[^\r\n]*/gi, '$1: [redacted]')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .slice(0, 500);
+};
+
+const sanitizeErrorForLog = (error: unknown) => {
+  const name = error instanceof Error ? error.name : 'Error';
+  const detail = sanitizeErrorDetail(error);
+
+  return `${name}: ${detail || 'unknown error'}`;
+};
+
 @injectable()
 export default class {
   private readonly client: Client;
@@ -100,14 +118,22 @@ export default class {
           }
         }
       } catch (error: unknown) {
-        debug(error);
+        const sanitizedError = sanitizeErrorForLog(error);
+        debug(sanitizedError);
+        const interactionName = interaction.isCommand() || interaction.isAutocomplete()
+          ? `/${interaction.commandName}`
+          : interaction.isButton()
+            ? `button:${interaction.customId}`
+            : interaction.type.toString();
+        console.error(`Discord interaction failed (${interactionName}, guild=${interaction.guildId ?? 'dm'}, channel=${interaction.channelId ?? 'unknown'}, user=${interaction.user.id}): ${sanitizedError}`);
+        const userSafeError = new Error(sanitizeErrorDetail(error));
 
         // This can fail if the message was deleted, and we don't want to crash the whole bot
         try {
           if ((interaction.isCommand() || interaction.isButton()) && (interaction.replied || interaction.deferred)) {
-            await interaction.editReply(errorMsg(error as Error));
+            await interaction.editReply(errorMsg(userSafeError));
           } else if (interaction.isCommand() || interaction.isButton()) {
-            await interaction.reply({content: errorMsg(error as Error), ephemeral: true});
+            await interaction.reply({content: errorMsg(userSafeError), ephemeral: true});
           }
         } catch {}
       }

--- a/src/commands/resume.ts
+++ b/src/commands/resume.ts
@@ -34,15 +34,17 @@ export default class implements Command {
       throw new Error('nothing to play');
     }
 
+    await interaction.deferReply({ephemeral: true});
     await player.connect(targetVoiceChannel);
     await player.play();
     if (!player.getCurrent()) {
       throw new Error('no playable songs found');
     }
 
-    await interaction.reply({
+    await interaction.followUp({
       content: 'the stop-and-go light is now green',
       embeds: [buildPlayingMessageEmbed(player)],
     });
+    await interaction.deleteReply().catch(() => undefined);
   }
 }

--- a/src/commands/skip.ts
+++ b/src/commands/skip.ts
@@ -32,15 +32,21 @@ export default class implements Command {
     }
 
     const player = this.playerManager.get(interaction.guild!.id);
+    await interaction.deferReply({ephemeral: true});
 
     try {
       await player.forward(numToSkip);
-      await interaction.reply({
+      await interaction.followUp({
         content: 'keep \'er movin\'',
         embeds: player.getCurrent() ? [buildPlayingMessageEmbed(player)] : [],
       });
-    } catch (_: unknown) {
-      throw new Error('no song to skip to');
+      await interaction.deleteReply().catch(() => undefined);
+    } catch (error: unknown) {
+      if (error instanceof Error && error.message === 'No songs in queue to forward to.') {
+        throw new Error('no song to skip to');
+      }
+
+      throw error;
     }
   }
 }

--- a/src/commands/unskip.ts
+++ b/src/commands/unskip.ts
@@ -22,15 +22,21 @@ export default class implements Command {
 
   public async execute(interaction: ChatInputCommandInteraction): Promise<void> {
     const player = this.playerManager.get(interaction.guild!.id);
+    await interaction.deferReply({ephemeral: true});
 
     try {
       await player.back();
-      await interaction.reply({
+      await interaction.followUp({
         content: 'back \'er up\'',
         embeds: player.getCurrent() ? [buildPlayingMessageEmbed(player)] : [],
       });
-    } catch (_: unknown) {
-      throw new Error('no song to go back to');
+      await interaction.deleteReply().catch(() => undefined);
+    } catch (error: unknown) {
+      if (error instanceof Error && error.message === 'No songs in queue to go back to.') {
+        throw new Error('no song to go back to');
+      }
+
+      throw error;
     }
   }
 }

--- a/src/services/add-query-to-queue.ts
+++ b/src/services/add-query-to-queue.ts
@@ -17,6 +17,12 @@ const isSameQueueEntry = (capturedId: number | null, currentId: number | null) =
   capturedId !== null && capturedId === currentId
 );
 
+const normalizeSkipError = (error: unknown) => (
+  error instanceof Error && error.message === 'No songs in queue to forward to.'
+    ? new Error('no song to skip to')
+    : error
+);
+
 @injectable()
 export default class AddQueryToQueue {
   private readonly sponsorBlock?: SponsorBlock;
@@ -124,8 +130,8 @@ export default class AddQueryToQueue {
       try {
         await player.forward(1);
         didSkipCurrentTrack = true;
-      } catch (_: unknown) {
-        throw new Error('no song to skip to');
+      } catch (error: unknown) {
+        throw normalizeSkipError(error);
       }
     }
 

--- a/src/services/file-cache.ts
+++ b/src/services/file-cache.ts
@@ -9,6 +9,11 @@ import debug from '../utils/debug.js';
 import {prisma} from '../utils/db.js';
 import {FileCache} from '@prisma/client';
 
+export type FileCacheEntry = {
+  generation: string;
+  path: string;
+};
+
 @injectable()
 export default class FileCacheProvider {
   private static readonly mutationQueue = new PQueue({concurrency: 1});
@@ -24,40 +29,50 @@ export default class FileCacheProvider {
    * @param hash lookup key
    */
   async getPathFor(hash: string): Promise<string | null> {
-    const model = await prisma.fileCache.findUnique({
-      where: {
-        hash,
-      },
-    });
+    return (await this.getEntryFor(hash))?.path ?? null;
+  }
 
-    if (!model) {
-      return null;
-    }
-
-    const resolvedPath = path.join(this.config.CACHE_DIR, hash);
-
-    try {
-      await fs.access(resolvedPath);
-    } catch (_: unknown) {
-      await prisma.fileCache.delete({
+  async getEntryFor(hash: string): Promise<FileCacheEntry | null> {
+    return (await FileCacheProvider.mutationQueue.add(async () => {
+      const model = await prisma.fileCache.findUnique({
         where: {
           hash,
         },
       });
 
-      return null;
-    }
+      if (!model) {
+        return null;
+      }
 
-    await prisma.fileCache.update({
-      where: {
-        hash,
-      },
-      data: {
-        accessedAt: new Date(),
-      },
-    });
+      const resolvedPath = path.join(this.config.CACHE_DIR, hash);
+      let stats;
 
-    return resolvedPath;
+      try {
+        stats = await fs.stat(resolvedPath, {bigint: true});
+      } catch (_: unknown) {
+        await prisma.fileCache.delete({
+          where: {
+            hash,
+          },
+        });
+
+        return null;
+      }
+
+      await prisma.fileCache.update({
+        where: {
+          hash,
+        },
+        data: {
+          accessedAt: new Date(),
+        },
+      });
+
+      return {
+        generation: this.getFileGeneration(stats),
+        path: resolvedPath,
+      };
+    })) ?? null;
   }
 
   /**
@@ -110,6 +125,47 @@ export default class FileCacheProvider {
       await this.removeOrphans();
       await this.evictOldest();
     });
+  }
+
+  async invalidate(hash: string, expectedGeneration: string) {
+    await FileCacheProvider.mutationQueue.add(async () => {
+      const resolvedPath = path.join(this.config.CACHE_DIR, hash);
+      try {
+        const stats = await fs.stat(resolvedPath, {bigint: true});
+        if (this.getFileGeneration(stats) !== expectedGeneration) {
+          return;
+        }
+      } catch (error: unknown) {
+        if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+          return;
+        }
+
+        throw error;
+      }
+
+      const model = await prisma.fileCache.findUnique({where: {hash}});
+      if (model) {
+        try {
+          await prisma.fileCache.delete({where: {hash}});
+        } catch (error: unknown) {
+          if ((error as {code?: string}).code !== 'P2025') {
+            throw error;
+          }
+        }
+      }
+
+      try {
+        await fs.unlink(resolvedPath);
+      } catch (error: unknown) {
+        if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
+          throw error;
+        }
+      }
+    });
+  }
+
+  private getFileGeneration(stats: {dev: bigint; ino: bigint; mtimeNs: bigint; size: bigint}) {
+    return `${stats.dev}:${stats.ino}:${stats.size}:${stats.mtimeNs}`;
   }
 
   private async finalizeWrite(hash: string, tmpPath: string, finalPath: string) {

--- a/src/services/player.ts
+++ b/src/services/player.ts
@@ -3,6 +3,7 @@ import {Readable} from 'stream';
 import hasha from 'hasha';
 import {WriteStream} from 'fs-capacitor';
 import ffmpeg from 'fluent-ffmpeg';
+import prismMedia from 'prism-media';
 import shuffle from 'array-shuffle';
 import {
   AudioPlayer,
@@ -37,6 +38,56 @@ import {Setting} from '@prisma/client';
 
 export {DEFAULT_VOLUME, MediaSource, STATUS};
 export type {AgeRestrictedFallbackResolver, PlayerEvents, QueuedPlaylist, QueuedSong, SongMetadata};
+
+const FFMPEG_STARTUP_TIMEOUT_MS = 20_000;
+
+const sanitizeFfmpegError = (error: unknown) => {
+  const detail = error instanceof Error ? error.message : String(error);
+
+  return detail
+    .replace(/https?:\/\/\S+/gi, '[media URL]')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .slice(0, 500);
+};
+
+const getMediaIdentifierForLog = (song: QueuedSong) => (
+  song.source === MediaSource.Youtube && /^[\w-]{11}$/.test(song.url)
+    ? `youtube=${song.url}`
+    : `sourceHash=${hasha(song.url).slice(0, 16)}`
+);
+
+export class FfmpegMediaUnavailableError extends Error {
+  constructor(error: unknown, public readonly reason: 'invalid-output' | 'not-found' | 'unavailable' = 'unavailable') {
+    const detail = sanitizeFfmpegError(error);
+    super(`FFmpeg could not start audio transcoding${detail ? `: ${detail}` : ''}`);
+    this.name = 'FfmpegMediaUnavailableError';
+  }
+}
+
+export class FfmpegStartupError extends Error {
+  constructor(error: unknown) {
+    const detail = sanitizeFfmpegError(error);
+    super(`FFmpeg could not initialize audio transcoding${detail ? `: ${detail}` : ''}`);
+    this.name = 'FfmpegStartupError';
+  }
+}
+
+const getFfmpegStartupError = (error: unknown) => {
+  const detail = error instanceof Error ? error.message : String(error);
+  const isInvalidOutput = /Invalid data found when processing input/i.test(detail);
+  const isNotFound = /(?:HTTP error|Server returned) (?:404|410)|404 Not Found|410 Gone/i.test(detail);
+
+  if (isInvalidOutput) {
+    return new FfmpegMediaUnavailableError(error, 'invalid-output');
+  }
+
+  if (isNotFound) {
+    return new FfmpegMediaUnavailableError(error, 'not-found');
+  }
+
+  return new FfmpegStartupError(error);
+};
 
 type PlayerPlaybackAttemptContext = PlaybackAttemptContext<QueuedSong, VoiceConnection>;
 
@@ -202,6 +253,7 @@ export default class {
   }
 
   async forward(skip: number): Promise<void> {
+    const originalPosition = this.positionInSeconds;
     const originalQueuePosition = this.queuePosition;
     const originalQueueEntryVersion = this.currentQueueEntryVersion;
     this.manualForward(skip);
@@ -231,6 +283,7 @@ export default class {
         && this.currentQueueEntryVersion === destinationQueueEntryVersion
         && (destinationPlayback === null || this.playbackAttempts.owns(destinationPlayback));
       if (failedTransitionStillOwnsDestination) {
+        this.positionInSeconds = originalPosition;
         this.queuePosition = originalQueuePosition;
         this.currentQueueEntryVersion = originalQueueEntryVersion;
       }
@@ -324,17 +377,47 @@ export default class {
   }
 
   async back(): Promise<void> {
-    if (this.canGoBack()) {
-      this.queuePosition--;
-      this.currentQueueEntryVersion++;
-      this.positionInSeconds = 0;
-      this.stopTrackingPosition();
-
-      if (this.status !== STATUS.PAUSED) {
-        await this.play();
-      }
-    } else {
+    if (!this.canGoBack()) {
       throw new Error('No songs in queue to go back to.');
+    }
+
+    const originalPosition = this.positionInSeconds;
+    const originalQueuePosition = this.queuePosition;
+    const originalQueueEntryVersion = this.currentQueueEntryVersion;
+    this.queuePosition--;
+    this.currentQueueEntryVersion++;
+    this.positionInSeconds = 0;
+    this.stopTrackingPosition();
+    const destinationSong = this.getCurrent();
+    const destinationQueueEntryVersion = this.currentQueueEntryVersion;
+    let destinationPlayback: PlayerPlaybackAttemptContext | null = null;
+
+    try {
+      if (this.status !== STATUS.PAUSED) {
+        const playPromise = this.play();
+        const destinationConnection = this.voiceConnection;
+        if (destinationConnection && destinationSong) {
+          destinationPlayback = this.playbackAttempts.capture(
+            this.playbackAttempts.latest(),
+            destinationSong,
+            destinationQueueEntryVersion,
+            destinationConnection,
+          );
+        }
+
+        await playPromise;
+      }
+    } catch (error: unknown) {
+      const failedTransitionStillOwnsDestination = this.getCurrent() === destinationSong
+        && this.currentQueueEntryVersion === destinationQueueEntryVersion
+        && (destinationPlayback === null || this.playbackAttempts.owns(destinationPlayback));
+      if (failedTransitionStillOwnsDestination) {
+        this.positionInSeconds = originalPosition;
+        this.queuePosition = originalQueuePosition;
+        this.currentQueueEntryVersion = originalQueueEntryVersion;
+      }
+
+      throw error;
     }
   }
 
@@ -486,7 +569,22 @@ export default class {
       to = currentSong.length + currentSong.offset;
     }
 
-    const stream = await this.getStream(currentSong, {seek: realPositionSeconds, to});
+    const previousPosition = this.positionInSeconds;
+    this.stopTrackingPosition();
+    let stream: Readable;
+    try {
+      stream = await this.getStream(currentSong, {seek: realPositionSeconds, to});
+    } catch (error: unknown) {
+      if (this.playbackAttempts.owns(playback)) {
+        this.positionInSeconds = previousPosition;
+        this.audioPlayer = null;
+        this.audioResource = null;
+      }
+
+      await this.handlePlaybackError(error, playback, true);
+      return;
+    }
+
     if (!this.playbackAttempts.owns(playback)) {
       this.destroyStaleStream(stream);
       return;
@@ -558,6 +656,8 @@ export default class {
       }
     }
 
+    const previousPosition = this.positionInSeconds;
+    this.stopTrackingPosition();
     try {
       let positionSeconds: number | undefined;
       let to: number | undefined;
@@ -588,6 +688,13 @@ export default class {
       this.nowPlayingQueueEntryVersion = currentQueueEntryVersion;
       this.startTrackingPosition(0);
     } catch (error: unknown) {
+      if (this.playbackAttempts.owns(playback)) {
+        this.positionInSeconds = previousPosition;
+        this.status = STATUS.PAUSED;
+        this.audioPlayer = null;
+        this.audioResource = null;
+      }
+
       await this.handlePlaybackError(
         error,
         playback,
@@ -623,9 +730,11 @@ export default class {
       }
     }
 
-    if (error instanceof YtDlpMediaUnavailableError || isGone) {
+    if (error instanceof YtDlpMediaUnavailableError
+      || error instanceof FfmpegMediaUnavailableError
+      || isGone) {
       const detail = error instanceof Error ? error.message : 'media returned HTTP 410';
-      console.warn(`Skipping unplayable YouTube track for guild ${this.guildId}: ${detail}`);
+      console.warn(`Skipping unplayable track for guild ${this.guildId} (${getMediaIdentifierForLog(playback.song)}): ${detail}`);
       await this.advancePastUnplayableTrack();
       return;
     }
@@ -652,7 +761,9 @@ export default class {
     const ffmpegInputOptions: string[] = [];
     let shouldCacheVideo = false;
 
-    ffmpegInput = await this.fileCache.getPathFor(this.getHashForCache(song.url));
+    const cacheHash = this.getHashForCache(song.url);
+    const cachedEntry = await this.fileCache.getEntryFor(cacheHash);
+    ffmpegInput = cachedEntry?.path ?? null;
 
     if (!ffmpegInput) {
       const mediaSource = await getYouTubeMediaSource(song.url);
@@ -685,12 +796,23 @@ export default class {
       ffmpegInputOptions.push('-to', options.to.toString());
     }
 
-    return this.createReadStream({
-      url: ffmpegInput,
-      cacheKey: song.url,
-      ffmpegInputOptions,
-      cache: shouldCacheVideo,
-    });
+    try {
+      return await this.createReadStream({
+        url: ffmpegInput,
+        cacheKey: song.url,
+        ffmpegInputOptions,
+        cache: shouldCacheVideo,
+      });
+    } catch (error: unknown) {
+      if (cachedEntry
+        && error instanceof FfmpegMediaUnavailableError
+        && error.reason === 'invalid-output') {
+        await this.fileCache.invalidate(cacheHash, cachedEntry.generation);
+        return this.getStream(song, options);
+      }
+
+      throw error;
+    }
   }
 
   private startTrackingPosition(initalPosition?: number): void {
@@ -913,14 +1035,116 @@ export default class {
   private async createReadStream(options: {url: string; cacheKey: string; ffmpegInputOptions?: string[]; cache?: boolean}): Promise<Readable> {
     return new Promise((resolve, reject) => {
       const capacitor = new WriteStream();
+      const startupProbeStream = capacitor.createReadStream();
+      const opusProbe = new prismMedia.opus.WebmDemuxer();
+      let cacheReadStream: Readable | undefined;
+      let cacheWriteStream: ReturnType<FileCacheProvider['createWriteStream']> | undefined;
 
       if (options?.cache) {
-        const cacheStream = this.fileCache.createWriteStream(this.getHashForCache(options.cacheKey));
-        capacitor.createReadStream().pipe(cacheStream);
+        cacheWriteStream = this.fileCache.createWriteStream(this.getHashForCache(options.cacheKey));
+        cacheReadStream = capacitor.createReadStream();
+        cacheReadStream.pipe(cacheWriteStream, {end: false});
       }
 
       const returnedStream = capacitor.createReadStream();
+      let cacheWriteAborted = false;
+      let cacheReadEnded = false;
+      let ffmpegEnded = false;
       let hasReturnedStreamClosed = false;
+      let startupSettled = false;
+      let startupTimedOut = false;
+      let startupTimeout: NodeJS.Timeout | undefined;
+
+      const cleanupStartupListeners = () => {
+        if (startupTimeout) {
+          clearTimeout(startupTimeout);
+          startupTimeout = undefined;
+        }
+
+        opusProbe.off('data', onPlayablePacket);
+        startupProbeStream.off('end', onEndBeforePlayablePacket);
+      };
+
+      const destroyCacheWrite = () => {
+        if (cacheWriteAborted) {
+          return;
+        }
+
+        cacheWriteAborted = true;
+        cacheReadStream?.destroy();
+        cacheWriteStream?.destroy();
+      };
+
+      const finalizeCacheWriteIfComplete = () => {
+        if (!cacheWriteAborted
+          && cacheReadEnded
+          && ffmpegEnded
+          && cacheWriteStream
+          && !cacheWriteStream.writableEnded) {
+          cacheWriteStream.end();
+        }
+      };
+
+      const rejectStartup = (error: unknown) => {
+        if (startupSettled) {
+          return;
+        }
+
+        startupSettled = true;
+        cleanupStartupListeners();
+        destroyCacheWrite();
+        startupProbeStream.destroy();
+        opusProbe.destroy();
+        returnedStream.destroy();
+        capacitor.destroy();
+        reject(error instanceof FfmpegMediaUnavailableError || error instanceof FfmpegStartupError
+          ? error
+          : new FfmpegStartupError(error));
+      };
+
+      const onPlayablePacket = () => {
+        if (startupSettled) {
+          return;
+        }
+
+        startupSettled = true;
+        cleanupStartupListeners();
+        startupProbeStream.destroy();
+        opusProbe.destroy();
+        resolve(returnedStream);
+      };
+
+      const onEndBeforePlayablePacket = () => {
+        if (ffmpegEnded) {
+          rejectStartup(new FfmpegMediaUnavailableError(
+            new Error('FFmpeg produced no playable Opus audio.'),
+            'invalid-output',
+          ));
+        }
+      };
+
+      const onFfmpegEnd = () => {
+        ffmpegEnded = true;
+        finalizeCacheWriteIfComplete();
+        if (startupProbeStream.readableEnded) {
+          onEndBeforePlayablePacket();
+        }
+      };
+
+      const onBufferError = (error: unknown) => {
+        if (!startupSettled) {
+          rejectStartup(new FfmpegStartupError(error));
+          return;
+        }
+
+        console.error(`Playback buffer failed after playback began for guild ${this.guildId}: ${sanitizeFfmpegError(error)}`);
+        destroyCacheWrite();
+      };
+
+      const onCacheWriteError = (error: unknown) => {
+        console.warn(`Disabling cache write for guild ${this.guildId}: ${sanitizeFfmpegError(error)}`);
+        destroyCacheWrite();
+      };
 
       const stream = ffmpeg(options.url)
         .inputOptions(options?.ffmpegInputOptions ?? ['-re'])
@@ -928,13 +1152,52 @@ export default class {
         .audioCodec('libopus')
         .outputFormat('webm')
         .on('error', error => {
-          if (!hasReturnedStreamClosed) {
-            reject(error);
+          destroyCacheWrite();
+
+          if (hasReturnedStreamClosed) {
+            return;
+          }
+
+          if (!startupSettled) {
+            rejectStartup(getFfmpegStartupError(error));
+            return;
+          }
+
+          console.error(`FFmpeg stream failed after playback began for guild ${this.guildId}: ${sanitizeFfmpegError(error)}`);
+          if (!capacitor.writableEnded) {
+            capacitor.end();
           }
         })
-        .on('start', command => {
-          debug(`Spawned ffmpeg with ${command}`);
-        });
+        .on('start', () => {
+          if (startupTimedOut) {
+            stream.kill('SIGKILL');
+            return;
+          }
+
+          debug('Spawned ffmpeg for playback');
+        })
+        .on('end', onFfmpegEnd);
+
+      capacitor.on('error', onBufferError);
+      startupProbeStream.on('error', onBufferError);
+      returnedStream.on('error', onBufferError);
+      opusProbe.on('error', onBufferError);
+      cacheReadStream?.on('error', onCacheWriteError);
+      cacheReadStream?.once('end', () => {
+        cacheReadEnded = true;
+        finalizeCacheWriteIfComplete();
+      });
+      cacheWriteStream?.on('error', onCacheWriteError);
+      opusProbe.once('data', onPlayablePacket);
+      startupProbeStream.once('end', onEndBeforePlayablePacket);
+      startupProbeStream.pipe(opusProbe);
+      startupTimeout = setTimeout(() => {
+        startupTimedOut = true;
+        stream.kill('SIGKILL');
+        rejectStartup(new FfmpegStartupError(
+          new Error(`FFmpeg produced no playable audio within ${FFMPEG_STARTUP_TIMEOUT_MS / 1000} seconds.`),
+        ));
+      }, FFMPEG_STARTUP_TIMEOUT_MS);
 
       stream.pipe(capacitor);
 
@@ -945,8 +1208,6 @@ export default class {
 
         hasReturnedStreamClosed = true;
       });
-
-      resolve(returnedStream);
     });
   }
 

--- a/tests/add-query-to-queue.test.ts
+++ b/tests/add-query-to-queue.test.ts
@@ -194,6 +194,16 @@ describe('AddQueryToQueue skip semantics', () => {
     expect(interaction.editReply).toHaveBeenLastCalledWith('u betcha, **New song** added to the queue and current track skipped');
   });
 
+  it('preserves playback startup failures from the skip path', async () => {
+    const player = makePausedPlayer(makeQueuedSong('Existing song'));
+    const failure = new Error('FFmpeg startup failed');
+    vi.spyOn(player, 'forward').mockRejectedValue(failure);
+    const {service} = makeService({player});
+    const interaction = makeInteraction();
+
+    await expect(addToQueue(service, interaction, {skip: true})).rejects.toBe(failure);
+  });
+
   it('does not skip after the captured current entry advances while song lookup is blocked', async () => {
     const player = makePausedPlayer(
       makeQueuedSong('Captured current'),

--- a/tests/bot-lifecycle.test.ts
+++ b/tests/bot-lifecycle.test.ts
@@ -127,10 +127,12 @@ interface StructuralCommand {
 }
 
 interface StructuralInteraction {
+  channelId: string | null;
   commandName: string;
   deferred: boolean;
   editReply: ReturnType<typeof vi.fn>;
   guild: object | null;
+  guildId: string | null;
   isAutocomplete: () => boolean;
   isButton: () => boolean;
   isChatInputCommand: () => boolean;
@@ -139,6 +141,8 @@ interface StructuralInteraction {
   options: {getSubcommand: () => string};
   replied: boolean;
   reply: ReturnType<typeof vi.fn>;
+  type: number;
+  user: {id: string};
 }
 
 const makeCommand = (name: string, overrides: Partial<StructuralCommand> = {}): StructuralCommand => ({
@@ -187,10 +191,12 @@ const makeClient = (guildIds: string[] = []) => {
 };
 
 const makeInteraction = (commandName: string, overrides: Partial<StructuralInteraction> = {}): StructuralInteraction => ({
+  channelId: 'channel-id',
   commandName,
   deferred: false,
   editReply: vi.fn().mockResolvedValue(undefined),
   guild: {channels: {cache: new Collection()}},
+  guildId: 'guild-id',
   isAutocomplete: () => false,
   isButton: () => false,
   isChatInputCommand: () => true,
@@ -199,6 +205,8 @@ const makeInteraction = (commandName: string, overrides: Partial<StructuralInter
   options: {getSubcommand: () => 'list'},
   replied: false,
   reply: vi.fn().mockResolvedValue(undefined),
+  type: 2,
+  user: {id: 'member-id'},
   ...overrides,
 });
 
@@ -419,6 +427,7 @@ describe('interaction boundaries', () => {
   });
 
   it('debug-logs command failures and sends a fresh ephemeral error response', async () => {
+    const errorLog = vi.spyOn(console, 'error').mockImplementation(() => undefined);
     const failure = new Error('command failure');
     const command = makeCommand('play', {execute: vi.fn().mockRejectedValue(failure)});
     const {handlers} = await registerBot(true, [command]);
@@ -426,9 +435,34 @@ describe('interaction boundaries', () => {
 
     await invoke(handlers, 'interactionCreate', interaction);
 
-    expect(mocks.debug).toHaveBeenCalledWith(failure);
+    expect(mocks.debug).toHaveBeenCalledWith('Error: command failure');
+    expect(errorLog).toHaveBeenCalledWith('Discord interaction failed (/play, guild=guild-id, channel=channel-id, user=member-id): Error: command failure');
     expect(interaction.reply).toHaveBeenCalledWith({content: '🚫 ope: command failure', ephemeral: true});
     expect(interaction.editReply).not.toHaveBeenCalled();
+  });
+
+  it('redacts case-insensitive URLs from interaction logs and user error responses', async () => {
+    const errorLog = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    const failure = new Error('request HTTPS://user:password@example.test/audio?token=secret failed Authorization: Basic basicsecret\r\nCookie: sid=sessionsecret; refresh=refreshsecret\r\n"token":"jsonsecret"');
+    const command = makeCommand('play', {execute: vi.fn().mockRejectedValue(failure)});
+    const {handlers} = await registerBot(true, [command]);
+    const interaction = makeInteraction('play');
+
+    await invoke(handlers, 'interactionCreate', interaction);
+
+    const sanitized = 'request [URL] failed Authorization: [redacted] Cookie: [redacted] "token":[redacted]';
+    expect(mocks.debug).toHaveBeenCalledWith(`Error: ${sanitized}`);
+    expect(errorLog).toHaveBeenCalledWith(expect.stringContaining(`Error: ${sanitized}`));
+    expect(errorLog.mock.calls.flat().join(' ')).not.toContain('password');
+    expect(errorLog.mock.calls.flat().join(' ')).not.toContain('token=secret');
+    expect(errorLog.mock.calls.flat().join(' ')).not.toContain('basicsecret');
+    expect(errorLog.mock.calls.flat().join(' ')).not.toContain('jsonsecret');
+    expect(errorLog.mock.calls.flat().join(' ')).not.toContain('sessionsecret');
+    expect(errorLog.mock.calls.flat().join(' ')).not.toContain('refreshsecret');
+    expect(interaction.reply).toHaveBeenCalledWith({
+      content: `🚫 ope: ${sanitized}`,
+      ephemeral: true,
+    });
   });
 
   it('edits deferred failures and swallows a failed error response', async () => {

--- a/tests/command-boundaries.test.ts
+++ b/tests/command-boundaries.test.ts
@@ -95,6 +95,8 @@ const makeInteraction = (options: {
   const reply = vi.fn().mockResolvedValue(undefined);
   const deferReply = vi.fn().mockResolvedValue(undefined);
   const editReply = vi.fn().mockResolvedValue(undefined);
+  const deleteReply = vi.fn().mockResolvedValue(undefined);
+  const followUp = vi.fn().mockResolvedValue(undefined);
 
   const interaction = {
     guild: {id: 'guild'},
@@ -107,9 +109,11 @@ const makeInteraction = (options: {
     reply,
     deferReply,
     editReply,
+    deleteReply,
+    followUp,
   } as unknown as ChatInputCommandInteraction;
 
-  return {interaction, reply, deferReply, editReply};
+  return {interaction, reply, deferReply, editReply, deleteReply, followUp};
 };
 
 const managerFor = (player: object) => ({get: () => player});
@@ -318,6 +322,50 @@ describe('/remove', () => {
 
     expect(upcoming).toEqual(['first']);
     expect(reply).toHaveBeenCalledWith(':wastebasket: removed');
+  });
+});
+
+describe('queue navigation error boundaries', () => {
+  it('publishes a successful /skip response after privately deferring failures', async () => {
+    const player = {
+      forward: vi.fn().mockResolvedValue(undefined),
+      getCurrent: vi.fn(() => null),
+    };
+    const {interaction, deferReply, deleteReply, followUp} = makeInteraction();
+
+    await new Skip(managerFor(player) as never).execute(interaction);
+
+    expect(deferReply).toHaveBeenCalledWith({ephemeral: true});
+    expect(followUp).toHaveBeenCalledWith({content: 'keep \'er movin\'', embeds: []});
+    expect(deleteReply).toHaveBeenCalledOnce();
+  });
+
+  it('defers /skip and preserves playback startup errors', async () => {
+    const failure = new Error('FFmpeg startup failed');
+    const player = {
+      forward: vi.fn().mockRejectedValue(failure),
+      getCurrent: vi.fn(() => ({title: 'Destination'})),
+    };
+    const {interaction, deferReply, editReply} = makeInteraction();
+
+    await expect(new Skip(managerFor(player) as never).execute(interaction)).rejects.toBe(failure);
+
+    expect(deferReply).toHaveBeenCalledWith({ephemeral: true});
+    expect(editReply).not.toHaveBeenCalled();
+  });
+
+  it('defers /unskip and preserves playback startup errors', async () => {
+    const failure = new Error('FFmpeg startup failed');
+    const player = {
+      back: vi.fn().mockRejectedValue(failure),
+      getCurrent: vi.fn(() => ({title: 'Destination'})),
+    };
+    const {interaction, deferReply, editReply} = makeInteraction();
+
+    await expect(new Unskip(managerFor(player) as never).execute(interaction)).rejects.toBe(failure);
+
+    expect(deferReply).toHaveBeenCalledWith({ephemeral: true});
+    expect(editReply).not.toHaveBeenCalled();
   });
 });
 

--- a/tests/file-cache.test.ts
+++ b/tests/file-cache.test.ts
@@ -154,6 +154,37 @@ afterEach(async () => {
 });
 
 describe('FileCacheProvider concurrent finalization', () => {
+  it('invalidates both an indexed cache row and its file', async () => {
+    const {cacheDirectory, provider} = await makeProvider();
+    const row = makeRow('corrupt-hash', 7);
+    dependencyMocks.rows.set(row.hash, row);
+    const cachedPath = path.join(cacheDirectory, row.hash);
+    await fs.writeFile(cachedPath, 'corrupt');
+    const entry = await provider.getEntryFor(row.hash);
+
+    await provider.invalidate(row.hash, entry!.generation);
+
+    expect(dependencyMocks.rows.has(row.hash)).toBe(false);
+    expect(await pathExists(cachedPath)).toBe(false);
+  });
+
+  it('does not invalidate a newer file generation for a late failing reader', async () => {
+    const {cacheDirectory, provider} = await makeProvider();
+    const row = makeRow('shared-hash', 7);
+    dependencyMocks.rows.set(row.hash, row);
+    const cachedPath = path.join(cacheDirectory, row.hash);
+    await fs.writeFile(cachedPath, 'corrupt');
+    const staleEntry = await provider.getEntryFor(row.hash);
+
+    await fs.unlink(cachedPath);
+    await fs.writeFile(cachedPath, 'valid replacement');
+    dependencyMocks.rows.set(row.hash, makeRow(row.hash, 17));
+    await provider.invalidate(row.hash, staleEntry!.generation);
+
+    expect(dependencyMocks.rows.has(row.hash)).toBe(true);
+    expect(await fs.readFile(cachedPath, 'utf8')).toBe('valid replacement');
+  });
+
   it('uses unique temporary paths and converges same-hash writers without an unhandled rejection', async () => {
     const {cacheDirectory, provider} = await makeProvider();
     const unhandledRejections: unknown[] = [];

--- a/tests/ops-integrations.test.ts
+++ b/tests/ops-integrations.test.ts
@@ -2,7 +2,7 @@ import 'reflect-metadata';
 import {promises as fs} from 'node:fs';
 import {tmpdir} from 'node:os';
 import path from 'node:path';
-import {Readable} from 'node:stream';
+import {PassThrough, Readable} from 'node:stream';
 import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
 
 const dependencyMocks = vi.hoisted(() => ({
@@ -49,6 +49,26 @@ vi.mock('fluent-ffmpeg', () => ({
   default: dependencyMocks.ffmpeg,
 }));
 
+vi.mock('prism-media', async () => {
+  const {Transform} = await import('node:stream');
+
+  return {
+    default: {
+      opus: {
+        WebmDemuxer: class extends Transform {
+          _transform(chunk: Buffer, _encoding: BufferEncoding, done: (error?: Error | null) => void) {
+            if (chunk.includes(1)) {
+              this.push(Buffer.from([0xf8, 0xff, 0xfe]));
+            }
+
+            done();
+          }
+        },
+      },
+    },
+  };
+});
+
 vi.mock('spotify-web-api-node', () => ({
   default: class {
     clientCredentialsGrant = dependencyMocks.spotifyClientCredentialsGrant;
@@ -76,7 +96,12 @@ vi.mock('../src/utils/debug.js', () => ({
   default: dependencyMocks.debug,
 }));
 
-import Player, {MediaSource, QueuedSong} from '../src/services/player.js';
+import Player, {
+  FfmpegMediaUnavailableError,
+  FfmpegStartupError,
+  MediaSource,
+  QueuedSong,
+} from '../src/services/player.js';
 import ThirdParty from '../src/services/third-party.js';
 import prepareYtDlp from '../src/utils/prepare-yt-dlp.js';
 import {getExecutable, getYouTubeMediaSource, getYtDlpVersion, updateYtDlp} from '../src/utils/yt-dlp.js';
@@ -124,18 +149,50 @@ const flushAsyncWork = async () => {
   }
 };
 
-const makeFfmpegCommand = () => {
+const makeFfmpegCommand = ({deferProcessResult = false, emptyOutput = false, hangOutput = false, headerOnlyOutput = false, startupError, startupErrorAfterOutput}: {
+  deferProcessResult?: boolean;
+  emptyOutput?: boolean;
+  hangOutput?: boolean;
+  headerOnlyOutput?: boolean;
+  startupError?: Error;
+  startupErrorAfterOutput?: Error;
+} = {}) => {
+  const handlers = new Map<string, (...args: unknown[]) => void>();
   const command = {
     audioCodec: vi.fn(() => command),
     inputOptions: vi.fn(() => command),
     kill: vi.fn(),
     noVideo: vi.fn(() => command),
-    on: vi.fn(() => command),
+    on: vi.fn((event: string, handler: (...args: unknown[]) => void) => {
+      handlers.set(event, handler);
+      return command;
+    }),
     outputFormat: vi.fn(() => command),
-    pipe: vi.fn((destination: {end(): void}) => {
+    pipe: vi.fn((destination: {end(): void; write(chunk: Buffer): void}) => {
+      if (startupError) {
+        handlers.get('error')?.(startupError);
+        return destination;
+      }
+
+      if (hangOutput) {
+        return destination;
+      }
+
+      if (!emptyOutput) {
+        destination.write(Buffer.from([headerOnlyOutput ? 2 : 1]));
+      }
       destination.end();
+      if (deferProcessResult) {
+        return destination;
+      } else if (startupErrorAfterOutput) {
+        handlers.get('error')?.(startupErrorAfterOutput);
+      } else {
+        handlers.get('end')?.();
+      }
       return destination;
     }),
+    triggerError: (error: Error) => handlers.get('error')?.(error),
+    triggerStart: () => handlers.get('start')?.(),
   };
 
   return command;
@@ -417,7 +474,7 @@ describe('OPS-11 yt-dlp extraction and ffmpeg handoff', () => {
   it('hands reconnect and CRLF-normalized headers to ffmpeg', async () => {
     process.env.YT_DLP_PATH = '/fake/yt-dlp';
     const fileCache = {
-      getPathFor: vi.fn().mockResolvedValue(null),
+      getEntryFor: vi.fn().mockResolvedValue(null),
     };
     const player = new Player(fileCache as never, GUILD_ID);
     const song: QueuedSong = {
@@ -456,6 +513,400 @@ describe('OPS-11 yt-dlp extraction and ffmpeg handoff', () => {
 
     stream.destroy();
     await flushAsyncWork();
+  });
+
+  it('rejects an FFmpeg startup failure before reporting a playable stream and redacts the signed URL', async () => {
+    process.env.YT_DLP_PATH = '/fake/yt-dlp';
+    const signedUrl = 'HTTPS://media.example/requested.webm?token=secret';
+    dependencyMocks.ffmpeg.mockImplementation(() => makeFfmpegCommand({
+      startupError: new Error(`${signedUrl}: Server returned 404 Not Found`),
+    }));
+    const fileCache = {
+      getEntryFor: vi.fn().mockResolvedValue(null),
+    };
+    const player = new Player(fileCache as never, GUILD_ID);
+    const song: QueuedSong = {
+      title: 'Rejected media URL',
+      artist: 'Artist',
+      url: 'abcdefghijk',
+      length: 3_600,
+      offset: 0,
+      playlist: null,
+      isLive: false,
+      thumbnailUrl: null,
+      source: MediaSource.Youtube,
+      addedInChannelId: 'text-channel-id',
+      requestedBy: 'requester-id',
+    };
+
+    const result = (player as unknown as {
+      getStream(input: QueuedSong): Promise<Readable>;
+    }).getStream(song);
+
+    await expect(result).rejects.toEqual(expect.objectContaining({
+      name: 'FfmpegMediaUnavailableError',
+      message: expect.stringContaining('[media URL]'),
+    }));
+    await expect(result).rejects.not.toEqual(expect.objectContaining({
+      message: expect.stringContaining('token=secret'),
+    }));
+    await expect(result).rejects.toBeInstanceOf(FfmpegMediaUnavailableError);
+  });
+
+  it('rejects an empty FFmpeg output instead of reporting playback', async () => {
+    dependencyMocks.ffmpeg.mockImplementation(() => makeFfmpegCommand({emptyOutput: true}));
+    const player = new Player({
+      getEntryFor: vi.fn().mockResolvedValue({generation: 'cached-generation', path: '/cached/audio.webm'}),
+    } as never, GUILD_ID);
+    const song: QueuedSong = {
+      title: 'Empty media output',
+      artist: 'Artist',
+      url: 'https://media.example/empty.webm',
+      length: 100,
+      offset: 0,
+      playlist: null,
+      isLive: false,
+      thumbnailUrl: null,
+      source: MediaSource.HLS,
+      addedInChannelId: 'text-channel-id',
+      requestedBy: 'requester-id',
+    };
+
+    const result = (player as unknown as {
+      getStream(input: QueuedSong): Promise<Readable>;
+    }).getStream(song);
+    await expect(result).rejects.toMatchObject({
+      name: 'FfmpegMediaUnavailableError',
+      message: expect.stringContaining('produced no playable Opus audio'),
+    });
+  });
+
+  it('preserves a startup timeout for retry instead of skipping the queue', async () => {
+    vi.useFakeTimers();
+    dependencyMocks.ffmpeg.mockImplementation(() => makeFfmpegCommand({hangOutput: true}));
+    const player = new Player({
+      getEntryFor: vi.fn().mockResolvedValue({generation: 'cached-generation', path: '/cached/audio.webm'}),
+    } as never, GUILD_ID);
+    const song: QueuedSong = {
+      title: 'Slow startup',
+      artist: 'Artist',
+      url: 'abcdefghijk',
+      length: 100,
+      offset: 0,
+      playlist: null,
+      isLive: false,
+      thumbnailUrl: null,
+      source: MediaSource.Youtube,
+      addedInChannelId: 'text-channel-id',
+      requestedBy: 'requester-id',
+    };
+
+    const result = (player as unknown as {
+      getStream(input: QueuedSong): Promise<Readable>;
+    }).getStream(song);
+    const expectation = expect(result).rejects.toMatchObject({
+      name: 'FfmpegStartupError',
+      message: expect.stringContaining('within 20 seconds'),
+    });
+
+    await vi.advanceTimersByTimeAsync(20_000);
+    await expectation;
+
+    const command = dependencyMocks.ffmpeg.mock.results[0].value as ReturnType<typeof makeFfmpegCommand>;
+    const killsBeforeLateStart = command.kill.mock.calls.length;
+    command.triggerStart();
+    expect(command.kill).toHaveBeenCalledTimes(killsBeforeLateStart + 1);
+    expect(command.kill).toHaveBeenLastCalledWith('SIGKILL');
+  });
+
+  it('waits for the FFmpeg result before classifying output EOF', async () => {
+    dependencyMocks.ffmpeg.mockImplementation(() => makeFfmpegCommand({
+      emptyOutput: true,
+      startupErrorAfterOutput: new Error('Server returned 403 Forbidden'),
+    }));
+    const player = new Player({
+      getEntryFor: vi.fn().mockResolvedValue({generation: 'cached-generation', path: '/cached/audio.webm'}),
+    } as never, GUILD_ID);
+    const song: QueuedSong = {
+      title: 'EOF before process result',
+      artist: 'Artist',
+      url: 'abcdefghijk',
+      length: 100,
+      offset: 0,
+      playlist: null,
+      isLive: false,
+      thumbnailUrl: null,
+      source: MediaSource.Youtube,
+      addedInChannelId: 'text-channel-id',
+      requestedBy: 'requester-id',
+    };
+
+    await expect((player as unknown as {
+      getStream(input: QueuedSong): Promise<Readable>;
+    }).getStream(song)).rejects.toBeInstanceOf(FfmpegStartupError);
+  });
+
+  it('does not accept a container header without a playable Opus packet', async () => {
+    dependencyMocks.ffmpeg.mockImplementation(() => makeFfmpegCommand({
+      headerOnlyOutput: true,
+    }));
+    const player = new Player({
+      getEntryFor: vi.fn().mockResolvedValue({generation: 'cached-generation', path: '/cached/audio.webm'}),
+    } as never, GUILD_ID);
+    const song: QueuedSong = {
+      title: 'Header-only output',
+      artist: 'Artist',
+      url: 'https://media.example/header-only.webm',
+      length: 100,
+      offset: 0,
+      playlist: null,
+      isLive: false,
+      thumbnailUrl: null,
+      source: MediaSource.HLS,
+      addedInChannelId: 'text-channel-id',
+      requestedBy: 'requester-id',
+    };
+
+    await expect((player as unknown as {
+      getStream(input: QueuedSong): Promise<Readable>;
+    }).getStream(song)).rejects.toBeInstanceOf(FfmpegMediaUnavailableError);
+  });
+
+  it('invalidates a corrupt cached input and retries from a fresh media URL', async () => {
+    dependencyMocks.ffmpeg
+      .mockImplementationOnce(() => makeFfmpegCommand({headerOnlyOutput: true}))
+      .mockImplementationOnce(() => makeFfmpegCommand());
+    const invalidate = vi.fn().mockResolvedValue(undefined);
+    const player = new Player({
+      getEntryFor: vi.fn()
+        .mockResolvedValueOnce({generation: 'corrupt-generation', path: '/cached/corrupt.webm'})
+        .mockResolvedValueOnce(null),
+      invalidate,
+    } as never, GUILD_ID);
+    const song: QueuedSong = {
+      title: 'Corrupt cached input',
+      artist: 'Artist',
+      url: 'abcdefghijk',
+      length: 3_600,
+      offset: 0,
+      playlist: null,
+      isLive: false,
+      thumbnailUrl: null,
+      source: MediaSource.Youtube,
+      addedInChannelId: 'text-channel-id',
+      requestedBy: 'requester-id',
+    };
+
+    const stream = await (player as unknown as {
+      getStream(input: QueuedSong): Promise<Readable>;
+    }).getStream(song);
+
+    expect(invalidate).toHaveBeenCalledWith(expect.any(String), 'corrupt-generation');
+    expect(dependencyMocks.ffmpeg).toHaveBeenNthCalledWith(1, '/cached/corrupt.webm');
+    expect(dependencyMocks.ffmpeg).toHaveBeenNthCalledWith(2, 'https://media.example/requested.webm');
+    stream.destroy();
+  });
+
+  it('preserves infrastructure-level FFmpeg startup failures', async () => {
+    dependencyMocks.ffmpeg.mockImplementation(() => makeFfmpegCommand({
+      startupError: new Error('spawn ffmpeg ENOENT'),
+    }));
+    const player = new Player({
+      getEntryFor: vi.fn().mockResolvedValue({generation: 'cached-generation', path: '/cached/audio.webm'}),
+    } as never, GUILD_ID);
+    const song: QueuedSong = {
+      title: 'Host failure',
+      artist: 'Artist',
+      url: 'abcdefghijk',
+      length: 100,
+      offset: 0,
+      playlist: null,
+      isLive: false,
+      thumbnailUrl: null,
+      source: MediaSource.Youtube,
+      addedInChannelId: 'text-channel-id',
+      requestedBy: 'requester-id',
+    };
+
+    await expect((player as unknown as {
+      getStream(input: QueuedSong): Promise<Readable>;
+    }).getStream(song)).rejects.toBeInstanceOf(FfmpegStartupError);
+  });
+
+  it('preserves transient HTTP failures for retry instead of skipping the queue', async () => {
+    dependencyMocks.ffmpeg.mockImplementation(() => makeFfmpegCommand({
+      startupError: new Error('Server returned 403 Forbidden'),
+    }));
+    const player = new Player({
+      getEntryFor: vi.fn().mockResolvedValue({generation: 'cached-generation', path: '/cached/audio.webm'}),
+    } as never, GUILD_ID);
+    const song: QueuedSong = {
+      title: 'Transient media failure',
+      artist: 'Artist',
+      url: 'abcdefghijk',
+      length: 100,
+      offset: 0,
+      playlist: null,
+      isLive: false,
+      thumbnailUrl: null,
+      source: MediaSource.Youtube,
+      addedInChannelId: 'text-channel-id',
+      requestedBy: 'requester-id',
+    };
+
+    await expect((player as unknown as {
+      getStream(input: QueuedSong): Promise<Readable>;
+    }).getStream(song)).rejects.toBeInstanceOf(FfmpegStartupError);
+  });
+
+  it('destroys an in-progress cache destination when FFmpeg fails during startup', async () => {
+    dependencyMocks.execa.mockResolvedValue({
+      stdout: JSON.stringify({
+        ...JSON.parse(VALID_MEDIA_RESPONSE),
+        is_live: false,
+      }),
+    });
+    dependencyMocks.ffmpeg.mockImplementation(() => makeFfmpegCommand({
+      startupError: new Error('Server returned 404 Not Found'),
+    }));
+    const cacheDestination = new PassThrough();
+    const destroyCacheDestination = vi.spyOn(cacheDestination, 'destroy');
+    const player = new Player({
+      createWriteStream: vi.fn(() => cacheDestination),
+      getEntryFor: vi.fn().mockResolvedValue(null),
+    } as never, GUILD_ID);
+    const song: QueuedSong = {
+      title: 'Cacheable rejected media',
+      artist: 'Artist',
+      url: 'abcdefghijk',
+      length: 100,
+      offset: 0,
+      playlist: null,
+      isLive: false,
+      thumbnailUrl: null,
+      source: MediaSource.Youtube,
+      addedInChannelId: 'text-channel-id',
+      requestedBy: 'requester-id',
+    };
+
+    await expect((player as unknown as {
+      getStream(input: QueuedSong): Promise<Readable>;
+    }).getStream(song)).rejects.toBeInstanceOf(FfmpegMediaUnavailableError);
+    expect(destroyCacheDestination).toHaveBeenCalledOnce();
+  });
+
+  it('finalizes a cache write only after FFmpeg exits successfully', async () => {
+    dependencyMocks.execa.mockResolvedValue({
+      stdout: JSON.stringify({
+        ...JSON.parse(VALID_MEDIA_RESPONSE),
+        is_live: false,
+      }),
+    });
+    const cacheDestination = new PassThrough();
+    const endCacheDestination = vi.spyOn(cacheDestination, 'end');
+    const player = new Player({
+      createWriteStream: vi.fn(() => cacheDestination),
+      getEntryFor: vi.fn().mockResolvedValue(null),
+    } as never, GUILD_ID);
+    const song: QueuedSong = {
+      title: 'Successful cache media',
+      artist: 'Artist',
+      url: 'abcdefghijk',
+      length: 100,
+      offset: 0,
+      playlist: null,
+      isLive: false,
+      thumbnailUrl: null,
+      source: MediaSource.Youtube,
+      addedInChannelId: 'text-channel-id',
+      requestedBy: 'requester-id',
+    };
+
+    const stream = await (player as unknown as {
+      getStream(input: QueuedSong): Promise<Readable>;
+    }).getStream(song);
+    await vi.waitFor(() => {
+      expect(endCacheDestination).toHaveBeenCalledOnce();
+    });
+    stream.destroy();
+  });
+
+  it('discards an in-progress cache if FFmpeg fails after the first playable packet', async () => {
+    dependencyMocks.ffmpeg.mockImplementation(() => makeFfmpegCommand({deferProcessResult: true}));
+    dependencyMocks.execa.mockResolvedValue({
+      stdout: JSON.stringify({
+        ...JSON.parse(VALID_MEDIA_RESPONSE),
+        is_live: false,
+      }),
+    });
+    const cacheDestination = new PassThrough();
+    const destroyCacheDestination = vi.spyOn(cacheDestination, 'destroy');
+    const player = new Player({
+      createWriteStream: vi.fn(() => cacheDestination),
+      getEntryFor: vi.fn().mockResolvedValue(null),
+    } as never, GUILD_ID);
+    const song: QueuedSong = {
+      title: 'Partially playable media',
+      artist: 'Artist',
+      url: 'abcdefghijk',
+      length: 100,
+      offset: 0,
+      playlist: null,
+      isLive: false,
+      thumbnailUrl: null,
+      source: MediaSource.Youtube,
+      addedInChannelId: 'text-channel-id',
+      requestedBy: 'requester-id',
+    };
+
+    const stream = await (player as unknown as {
+      getStream(input: QueuedSong): Promise<Readable>;
+    }).getStream(song);
+    const command = dependencyMocks.ffmpeg.mock.results[0].value as ReturnType<typeof makeFfmpegCommand>;
+    command.triggerError(new Error('Server returned 403 Forbidden'));
+    await flushAsyncWork();
+
+    expect(destroyCacheDestination).toHaveBeenCalledOnce();
+    stream.destroy();
+  });
+
+  it('discards an in-progress cache if FFmpeg fails after the playback reader closes', async () => {
+    dependencyMocks.ffmpeg.mockImplementation(() => makeFfmpegCommand({deferProcessResult: true}));
+    dependencyMocks.execa.mockResolvedValue({
+      stdout: JSON.stringify({
+        ...JSON.parse(VALID_MEDIA_RESPONSE),
+        is_live: false,
+      }),
+    });
+    const cacheDestination = new PassThrough();
+    const destroyCacheDestination = vi.spyOn(cacheDestination, 'destroy');
+    const player = new Player({
+      createWriteStream: vi.fn(() => cacheDestination),
+      getEntryFor: vi.fn().mockResolvedValue(null),
+    } as never, GUILD_ID);
+    const song: QueuedSong = {
+      title: 'Stopped partial media',
+      artist: 'Artist',
+      url: 'abcdefghijk',
+      length: 100,
+      offset: 0,
+      playlist: null,
+      isLive: false,
+      thumbnailUrl: null,
+      source: MediaSource.Youtube,
+      addedInChannelId: 'text-channel-id',
+      requestedBy: 'requester-id',
+    };
+
+    const stream = await (player as unknown as {
+      getStream(input: QueuedSong): Promise<Readable>;
+    }).getStream(song);
+    const command = dependencyMocks.ffmpeg.mock.results[0].value as ReturnType<typeof makeFfmpegCommand>;
+    stream.destroy();
+    command.triggerError(new Error('Server returned 403 Forbidden'));
+    await flushAsyncWork();
+
+    expect(destroyCacheDestination).toHaveBeenCalledOnce();
   });
 });
 

--- a/tests/playback-gaps.test.ts
+++ b/tests/playback-gaps.test.ts
@@ -66,7 +66,7 @@ vi.mock('../src/utils/channels.js', () => ({
 
 import Play from '../src/commands/play.js';
 import AddQueryToQueue from '../src/services/add-query-to-queue.js';
-import Player, {MediaSource, QueuedSong, SongMetadata, STATUS} from '../src/services/player.js';
+import Player, {FfmpegMediaUnavailableError, MediaSource, QueuedSong, SongMetadata, STATUS} from '../src/services/player.js';
 import {getYouTubeMediaSource, YtDlpMediaUnavailableError} from '../src/utils/yt-dlp.js';
 
 const GUILD_ID = 'guild-id';
@@ -123,7 +123,9 @@ const makeReadyPlayer = () => {
 };
 
 const makeProductionStreamPlayer = () => {
-  const fileCache = {getPathFor: vi.fn().mockResolvedValue('/cached/audio.webm')};
+  const fileCache = {
+    getEntryFor: vi.fn().mockResolvedValue({generation: 'cached-generation', path: '/cached/audio.webm'}),
+  };
   const player = new Player(fileCache as never, GUILD_ID);
   const voiceConnection = makeVoiceConnection();
   const createReadStream = vi.fn().mockResolvedValue(Readable.from([]));
@@ -564,6 +566,7 @@ describe('PLAY-14 unplayable queue continuation preservation', () => {
     [new YtDlpMediaUnavailableError('private video', 'unavailable'), 'private media'],
     [new YtDlpMediaUnavailableError('video has been removed', 'unavailable'), 'removed media'],
     [new YtDlpMediaUnavailableError('sign in to confirm your age', 'age-restricted'), 'age-restricted media without a fallback'],
+    [new FfmpegMediaUnavailableError(new Error('Server returned 403 Forbidden')), 'rejected FFmpeg media URL'],
     [{statusCode: 410}, 'HTTP 410 media'],
   ])('advances exactly once past %s (%s)', async playbackError => {
     const warning = vi.spyOn(console, 'warn').mockImplementation(() => undefined);

--- a/tests/player-state.test.ts
+++ b/tests/player-state.test.ts
@@ -116,6 +116,7 @@ const getPrivateState = (player: Player) => player as unknown as {
   nowPlaying: QueuedSong | null;
   nowPlayingQueueEntryVersion: number | null;
   playAudioPlayerResource(resource: object): void;
+  startTrackingPosition(position?: number): void;
 };
 
 const installVoiceActivityFakes = (player: Player) => {
@@ -166,18 +167,90 @@ afterEach(() => {
 });
 
 describe('Player forward state transitions', () => {
+  it('clears a stopped audio player after a failed seek so play can retry the prior position', async () => {
+    const {getStream, player} = makeReadyPlayer();
+    const song = makeSong('Seek retry');
+    const oldAudioPlayer = makeAudioPlayer();
+    player.add(song);
+    player.status = STATUS.PLAYING;
+    Object.assign(player, {
+      audioPlayer: oldAudioPlayer,
+      nowPlaying: song,
+      nowPlayingQueueEntryVersion: 1,
+    });
+    getPrivateState(player).startTrackingPosition(12);
+    const seekFailure = makeDeferred<Readable>();
+    getStream.mockReturnValueOnce(seekFailure.promise);
+
+    const seek = player.seek(30);
+    await Promise.resolve();
+    await vi.advanceTimersByTimeAsync(20_000);
+    seekFailure.reject(new Error('transient FFmpeg failure'));
+    await expect(seek).rejects.toThrow('transient FFmpeg failure');
+
+    expect(getPrivateState(player).audioPlayer).toBeNull();
+    expect(player.status).toBe(STATUS.PAUSED);
+    await vi.advanceTimersByTimeAsync(3_000);
+    expect(player.getPosition()).toBe(12);
+
+    getStream.mockResolvedValueOnce(Readable.from([]));
+    await player.play();
+
+    expect(getStream).toHaveBeenLastCalledWith(song, {seek: 12, to: 100});
+    expect(player.status).toBe(STATUS.PLAYING);
+    expect(getPrivateState(player).audioPlayer).not.toBeNull();
+  });
+
+  it('restores a retryable paused state after a transient play startup failure', async () => {
+    const {getStream, player} = makeReadyPlayer();
+    const song = makeSong('Transient retry');
+    player.add(song);
+    player.status = STATUS.PLAYING;
+    Object.assign(player, {
+      audioPlayer: makeAudioPlayer(),
+      nowPlaying: song,
+      nowPlayingQueueEntryVersion: 1,
+    });
+    getPrivateState(player).startTrackingPosition(9);
+    getStream.mockRejectedValueOnce(new Error('transient FFmpeg failure'));
+
+    await expect(player.play()).rejects.toThrow('transient FFmpeg failure');
+
+    expect(player.status).toBe(STATUS.PAUSED);
+    expect(getPrivateState(player).audioPlayer).toBeNull();
+    await vi.advanceTimersByTimeAsync(3_000);
+    expect(player.getPosition()).toBe(9);
+  });
+
   it('restores the exact original queue position when a multi-skip destination fails to play', async () => {
     const player = new Player({} as never, GUILD_ID);
     player.add(makeSong('Original'));
     player.add(makeSong('Skipped'));
     player.add(makeSong('Failed destination'));
     player.status = STATUS.PLAYING;
+    Object.assign(player, {positionInSeconds: 47});
     vi.spyOn(player, 'play').mockRejectedValue(new Error('playback failed'));
 
     await expect(player.forward(2)).rejects.toThrow('playback failed');
 
     expect(player.getCurrent()?.title).toBe('Original');
+    expect(player.getPosition()).toBe(47);
     expect(player.getQueue().map(song => song.title)).toEqual(['Skipped', 'Failed destination']);
+  });
+
+  it('restores the exact original queue position when an unskip destination fails to play', async () => {
+    const player = new Player({} as never, GUILD_ID);
+    player.add(makeSong('Previous'));
+    player.add(makeSong('Original'));
+    player.manualForward(1);
+    player.status = STATUS.PLAYING;
+    Object.assign(player, {positionInSeconds: 31});
+    vi.spyOn(player, 'play').mockRejectedValue(new Error('playback failed'));
+
+    await expect(player.back()).rejects.toThrow('playback failed');
+
+    expect(player.getCurrent()?.title).toBe('Original');
+    expect(player.getPosition()).toBe(31);
   });
 
   it('moves a paused non-empty queue forward while remaining paused and never schedules idle disconnect', async () => {


### PR DESCRIPTION
## Summary

- wait for the first valid Opus packet before reporting playback startup, and surface FFmpeg startup failures instead of silently ending streams
- distinguish unavailable media from transient upstream failures so queue and seek state roll back safely
- make cache writes atomic across FFmpeg completion and concurrent invalidation, and preserve actionable command errors
- sanitize interaction error reporting while retaining enough context to diagnose failures

## Production evidence

Recent PCT118 failures for `jDRTghGZ7XU` and `_osKm4gGOFo` resolved the signed YouTube URL but FFmpeg immediately received HTTP 403. The previous stream factory had already resolved, so the later error was discarded and Discord received an empty stream.

A PCT118 image built from this commit with yt-dlp 2026.08.19 is running successfully. Replaying the exact failed media IDs through the deployed downloader and FFmpeg produced valid Opus/WebM output. The known age-gated original still fails explicitly, and its configured fallback produces valid output.

## Validation

- 274 tests passed
- typecheck passed
- lint passed
- production build passed
- autoreview clean
