### PR TITLE
Fix SoundCloud URL playback and playlist handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Resolve SoundCloud tracks, share links, and bounded playlists with yt-dlp instead of probing HTML pages as audio streams, and refresh media URLs when playback begins.
+
 ## [2.11.7] - 2026-08-20
 
 - Detect FFmpeg failures before reporting playback as started, skip failed queued tracks instead of wedging the player, and retain bounded failure details in the container log.

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Muse is a **highly-opinionated midwestern self-hosted** Discord music bot **that
 ## Features
 
 - 🎥 Livestreams
+- ☁️ SoundCloud tracks, share links, and playlists
 - ⏩ Seeking within a song/video
 - 💾 Local caching for better performance
 - 📋 No vote-to-skip - this is anarchy, not a democracy

--- a/src/services/get-songs.ts
+++ b/src/services/get-songs.ts
@@ -6,6 +6,8 @@ import ffmpeg from 'fluent-ffmpeg';
 import YoutubeAPI from './youtube-api.js';
 import SpotifyAPI, {SpotifyTrack} from './spotify-api.js';
 import {URL} from 'node:url';
+import {getSoundCloudMetadata, YtDlpMediaUnavailableError} from '../utils/yt-dlp.js';
+import pLimit from 'p-limit';
 
 @injectable()
 export default class {
@@ -67,6 +69,8 @@ export default class {
           throw new Error('that doesn\'t exist');
         }
       }
+    } else if (['soundcloud.com', 'www.soundcloud.com', 'm.soundcloud.com', 'on.soundcloud.com', 'snd.sc'].includes(url.host)) {
+      newSongs.push(...await this.soundCloudSource(url.href, playlistLimit));
     } else if (url.protocol === 'spotify:' || url.host === 'open.spotify.com') {
       if (this.spotifyAPI === undefined) {
         throw new Error('Spotify is not enabled!');
@@ -171,6 +175,54 @@ export default class {
         });
       });
     });
+  }
+
+  private async soundCloudSource(url: string, playlistLimit: number): Promise<SongMetadata[]> {
+    const metadata = await getSoundCloudMetadata(url, playlistLimit);
+    const playlist = metadata.entries ? {title: metadata.title ?? 'SoundCloud playlist', source: url} : null;
+    const tracks = metadata.entries ?? [metadata];
+
+    const limit = pLimit(4);
+    const songs = await Promise.all(tracks.slice(0, playlistLimit).map(async track => limit(async () => {
+      if (!track) {
+        return [];
+      }
+
+      // Keep the page URL in the queue; signed audio URLs must be resolved at playback time.
+      const trackUrl = playlist ? track.webpage_url ?? track.url : url;
+      if (!trackUrl) {
+        return [];
+      }
+
+      // Flat SoundCloud playlist entries can contain only a URL, with no title or duration.
+      let details;
+      try {
+        details = playlist ? await getSoundCloudMetadata(trackUrl, 1) : track;
+      } catch (error: unknown) {
+        if (error instanceof YtDlpMediaUnavailableError) {
+          return [];
+        }
+
+        throw error;
+      }
+
+      if (details.entries || !details.title) {
+        return [];
+      }
+
+      return [{
+        url: trackUrl,
+        source: MediaSource.SoundCloud,
+        isLive: false,
+        title: details.title,
+        artist: details.artist ?? details.uploader ?? 'SoundCloud',
+        length: Math.max(0, details.duration ?? 0),
+        offset: 0,
+        playlist,
+        thumbnailUrl: details.thumbnail ?? null,
+      }];
+    })));
+    return songs.flat();
   }
 
   private async spotifyToYouTube(tracks: SpotifyTrack[], shouldSplitChapters: boolean, playlist?: QueuedPlaylist | undefined): Promise<[SongMetadata[], number, number]> {

--- a/src/services/player-types.ts
+++ b/src/services/player-types.ts
@@ -3,6 +3,7 @@ import type {Snowflake} from 'discord.js';
 export enum MediaSource {
   Youtube,
   HLS,
+  SoundCloud,
 }
 
 export interface QueuedPlaylist {

--- a/src/services/player.ts
+++ b/src/services/player.ts
@@ -33,7 +33,7 @@ import {destroyVoiceConnection, recoverVoiceConnection} from './voice-connection
 import debug from '../utils/debug.js';
 import {getGuildSettings} from '../utils/get-guild-settings.js';
 import {buildPlayingMessageEmbed} from '../utils/build-embed.js';
-import {getYouTubeMediaSource, YtDlpMediaUnavailableError} from '../utils/yt-dlp.js';
+import {getSoundCloudMediaSource, getYouTubeMediaSource, YtDlpMediaUnavailableError} from '../utils/yt-dlp.js';
 import {Setting} from '@prisma/client';
 
 export {DEFAULT_VOLUME, MediaSource, STATUS};
@@ -766,7 +766,9 @@ export default class {
     ffmpegInput = cachedEntry?.path ?? null;
 
     if (!ffmpegInput) {
-      const mediaSource = await getYouTubeMediaSource(song.url);
+      const mediaSource = await (song.source === MediaSource.SoundCloud
+        ? getSoundCloudMediaSource(song.url)
+        : getYouTubeMediaSource(song.url));
       ffmpegInput = mediaSource.url;
 
       // Don't cache livestreams or long videos

--- a/src/utils/build-embed.ts
+++ b/src/utils/build-embed.ts
@@ -19,6 +19,12 @@ const getSongTitle = ({title, url, offset, source}: QueuedSong, shouldTruncate =
   const cleanSongTitle = title.replace(/\[.*\]/, '').trim();
 
   const songTitle = shouldTruncate ? truncate(cleanSongTitle, getMaxSongTitleLength(cleanSongTitle)) : cleanSongTitle;
+  if (source === MediaSource.SoundCloud) {
+    const soundCloudTitle = truncate(songTitle, 256);
+    // Keep long share parameters in the playable URL without overflowing Discord embeds.
+    return url.length > 1024 ? soundCloudTitle : `[${soundCloudTitle}](${url})`;
+  }
+
   const youtubeId = url.length === 11 ? url : getYouTubeID(url) ?? '';
 
   return `[${songTitle}](https://www.youtube.com/watch?v=${youtubeId}${offset === 0 ? '' : '&t=' + String(offset)})`;
@@ -103,8 +109,7 @@ export const buildQueueEmbed = (player: Player, page: number, pageSize: number):
       const duration = song.isLive ? 'live' : prettyTime(song.length);
 
       return `\`${songNumber}.\` ${getSongTitle(song, true)} \`[${duration}]\``;
-    })
-    .join('\n');
+    });
 
   const {artist, thumbnailUrl, playlist, requestedBy} = currentlyPlaying;
   const playlistTitle = playlist ? `(${playlist.title})` : '';
@@ -118,7 +123,16 @@ export const buildQueueEmbed = (player: Player, page: number, pageSize: number):
 
   if (player.getQueue().length > 0) {
     description += '**Up next:**\n';
-    description += queuedSongs;
+    for (const [index, song] of queuedSongs.entries()) {
+      // Leave room for a useful hint instead of rejecting the entire /queue response.
+      const overflowMessage = `… ${queuedSongs.length - index} more on this page; use a smaller page-size to view them.`;
+      if (description.length + song.length + 1 + overflowMessage.length > 4096) {
+        description += overflowMessage;
+        break;
+      }
+
+      description += `${song}\n`;
+    }
   }
 
   message

--- a/src/utils/time.ts
+++ b/src/utils/time.ts
@@ -1,5 +1,5 @@
 export const prettyTime = (seconds: number): string => {
-  const nSeconds = seconds % 60;
+  const nSeconds = Math.floor(seconds) % 60;
   let nMinutes = Math.floor(seconds / 60);
   const nHours = Math.floor(nMinutes / 60);
 

--- a/src/utils/yt-dlp.ts
+++ b/src/utils/yt-dlp.ts
@@ -22,6 +22,17 @@ interface YtDlpResponse extends YtDlpMediaDownload {
   readonly requested_downloads?: readonly YtDlpMediaDownload[];
 }
 
+export interface SoundCloudMetadata {
+  readonly title?: string;
+  readonly uploader?: string;
+  readonly artist?: string;
+  readonly duration?: number;
+  readonly webpage_url?: string;
+  readonly url?: string;
+  readonly thumbnail?: string;
+  readonly entries?: ReadonlyArray<SoundCloudMetadata | null>;
+}
+
 export interface YtDlpMediaSource {
   readonly url: string;
   readonly headers: Record<string, string>;
@@ -60,6 +71,9 @@ const getMediaUnavailableReason = (detail: string): YtDlpMediaUnavailableReason 
     /private video/i,
     /video has been removed/i,
     /members-only content/i,
+    /this track is not available/i,
+    /DRM protected/i,
+    /\[soundcloud\][\s\S]*HTTP Error (404|410)\b/i,
   ].some(pattern => pattern.test(detail))
     ? 'unavailable'
     : null;
@@ -69,8 +83,8 @@ const firstNonEmpty = (...values: Array<string | undefined>) => values
   .map(value => value?.trim())
   .find((value): value is string => Boolean(value));
 
-const withTemporaryCookies = async <T>(operation: (cookiesPath?: string) => Promise<T>): Promise<T> => {
-  const configuredCookiesPath = firstNonEmpty(process.env.YT_DLP_COOKIES_PATH);
+const withTemporaryCookies = async <T>(operation: (cookiesPath?: string) => Promise<T>, enabled = true): Promise<T> => {
+  const configuredCookiesPath = enabled ? firstNonEmpty(process.env.YT_DLP_COOKIES_PATH) : undefined;
   if (!configuredCookiesPath) {
     return operation();
   }
@@ -294,12 +308,12 @@ export const updateYtDlp = async (): Promise<YtDlpUpdateResult> => {
   };
 };
 
-export const getYouTubeMediaSource = async (videoIdOrUrl: string): Promise<YtDlpMediaSource> => {
+const extractMedia = async (url: string, playlistLimit?: number, useYouTubeCookies = true): Promise<YtDlpResponse & SoundCloudMetadata> => {
   try {
     return await withTemporaryCookies(async cookiesPath => {
       const args = [
         '--dump-single-json',
-        '--no-playlist',
+        ...(playlistLimit === undefined ? ['--no-playlist'] : ['--flat-playlist', '--playlist-end', String(playlistLimit)]),
         '--skip-download',
         '--no-warnings',
         '--no-cache-dir',
@@ -315,25 +329,14 @@ export const getYouTubeMediaSource = async (videoIdOrUrl: string): Promise<YtDlp
         args.push('--cookies', cookiesPath);
       }
 
-      args.push(toYouTubeWatchUrl(videoIdOrUrl));
+      args.push(url);
 
       const {stdout} = await execa(getExecutable(), args, {
         timeout: YT_DLP_EXTRACT_TIMEOUT_MS,
       });
 
-      const response = JSON.parse(stdout) as YtDlpResponse;
-      const download = response.requested_downloads?.at(0) ?? response;
-
-      if (!download.url) {
-        throw new Error('yt-dlp did not return a playable media URL.');
-      }
-
-      return {
-        url: download.url,
-        headers: normalizeHeaders(download.http_headers ?? response.http_headers),
-        isLive: Boolean(response.is_live ?? (response.live_status === 'is_live')),
-      };
-    });
+      return JSON.parse(stdout) as YtDlpResponse & SoundCloudMetadata;
+    }, useYouTubeCookies);
   } catch (error: unknown) {
     if (isExecaError(error)) {
       const detail = error.stderr?.trim() ?? error.shortMessage ?? 'Unknown yt-dlp error';
@@ -354,3 +357,29 @@ export const getYouTubeMediaSource = async (videoIdOrUrl: string): Promise<YtDlp
     throw error;
   }
 };
+
+const toMediaSource = (response: YtDlpResponse): YtDlpMediaSource => {
+  const download = response.requested_downloads?.at(0) ?? response;
+
+  if (!download.url || 'entries' in response) {
+    throw new Error('yt-dlp did not return a playable media URL.');
+  }
+
+  return {
+    url: download.url,
+    headers: normalizeHeaders(download.http_headers ?? response.http_headers),
+    isLive: Boolean(response.is_live ?? (response.live_status === 'is_live')),
+  };
+};
+
+export const getYouTubeMediaSource = async (videoIdOrUrl: string): Promise<YtDlpMediaSource> => (
+  toMediaSource(await extractMedia(toYouTubeWatchUrl(videoIdOrUrl)))
+);
+
+export const getSoundCloudMetadata = async (url: string, playlistLimit: number): Promise<SoundCloudMetadata> => (
+  extractMedia(url, Math.max(1, Math.floor(playlistLimit)), false)
+);
+
+export const getSoundCloudMediaSource = async (url: string): Promise<YtDlpMediaSource> => (
+  toMediaSource(await extractMedia(url, undefined, false))
+);

--- a/tests/command-boundaries.test.ts
+++ b/tests/command-boundaries.test.ts
@@ -27,7 +27,7 @@ vi.mock('../src/utils/db.js', () => ({
 vi.mock('../src/services/player.js', () => ({
   default: class {},
   STATUS: {PLAYING: 0, PAUSED: 1, IDLE: 2},
-  MediaSource: {Youtube: 0, HLS: 1},
+  MediaSource: {Youtube: 0, HLS: 1, SoundCloud: 2},
   DEFAULT_VOLUME: 100,
 }));
 
@@ -53,7 +53,7 @@ import Skip from '../src/commands/skip.js';
 import Stop from '../src/commands/stop.js';
 import Unskip from '../src/commands/unskip.js';
 import Volume from '../src/commands/volume.js';
-import {buildQueueEmbed} from '../src/utils/build-embed.js';
+import {buildPlayingMessageEmbed, buildQueueEmbed} from '../src/utils/build-embed.js';
 import durationStringToSeconds from '../src/utils/duration-string-to-seconds.js';
 
 const STATUS = {PLAYING: 0, PAUSED: 1, IDLE: 2} as const;
@@ -276,6 +276,40 @@ describe('command metadata', () => {
 });
 
 describe('/queue', () => {
+  it('links SoundCloud tracks to SoundCloud and shows their finite duration', () => {
+    const song = {...makeSong(1), source: 2, url: 'https://soundcloud.com/artist/track'};
+    const player = {...makeQueuePlayer(0), getCurrent: () => song};
+    const embed = buildQueueEmbed(player as never, 1, 10).toJSON();
+    expect(embed.description).toContain('[Song 1](https://soundcloud.com/artist/track)');
+    expect(embed.description).toContain('[00:00/02:00]');
+    expect(embed.description).not.toContain('youtube.com');
+  });
+
+  it('bounds a full queue page containing long SoundCloud titles and URLs', () => {
+    const player = {...makeQueuePlayer(30), getQueue: () => Array.from({length: 30}, (_, i) => ({
+      ...makeSong(i + 2), source: 2, title: 'x'.repeat(100),
+      url: `https://soundcloud.com/artist/${'long-track-slug-'.repeat(15)}${i}`,
+    }))};
+    const embed = buildQueueEmbed(player as never, 1, 30).toJSON();
+    expect(embed.description!.length).toBeLessThanOrEqual(4096);
+    expect(embed.description).not.toContain('x'.repeat(100));
+    expect(embed.description).toContain('use a smaller page-size');
+  });
+
+  it('keeps current-track embeds valid for oversized SoundCloud share URLs', () => {
+    const song = {...makeSong(1), source: 2, length: 59.9,
+      url: `https://soundcloud.com/artist/track?tracking=${'x'.repeat(5000)}`};
+    const player = {...makeQueuePlayer(0), getCurrent: () => song};
+    for (const embed of [buildQueueEmbed(player as never, 1, 10), buildPlayingMessageEmbed(player as never)]) {
+      const {description} = embed.toJSON();
+      expect(description!.length).toBeLessThanOrEqual(4096);
+      expect(description).toContain('Song 1');
+      expect(description).not.toContain('tracking=');
+      expect(description).toContain('[00:00/00:59]');
+    }
+    expect(song.length).toBe(59.9);
+  });
+
   it('shows page 1 for a current-only queue', () => {
     const embed = buildQueueEmbed(makeQueuePlayer(0) as never, 1, 10).toJSON();
 

--- a/tests/ops-integrations.test.ts
+++ b/tests/ops-integrations.test.ts
@@ -104,7 +104,7 @@ import Player, {
 } from '../src/services/player.js';
 import ThirdParty from '../src/services/third-party.js';
 import prepareYtDlp from '../src/utils/prepare-yt-dlp.js';
-import {getExecutable, getYouTubeMediaSource, getYtDlpVersion, updateYtDlp} from '../src/utils/yt-dlp.js';
+import {getExecutable, getSoundCloudMetadata, getSoundCloudMediaSource, getYouTubeMediaSource, getYtDlpVersion, updateYtDlp, YtDlpMediaUnavailableError} from '../src/utils/yt-dlp.js';
 
 const GUILD_ID = 'guild-id';
 const ORIGINAL_ENV = {
@@ -442,6 +442,37 @@ describe('OPS-10 yt-dlp selection and update lifecycle', () => {
 });
 
 describe('OPS-11 yt-dlp extraction and ffmpeg handoff', () => {
+  it('bounds SoundCloud collection extraction and does not read YouTube cookies', async () => {
+    process.env.YT_DLP_COOKIES_PATH = '/missing/youtube-only-cookies';
+    const metadata = {title: 'Album', entries: [{title: 'Track', url: 'https://soundcloud.com/artist/track'}]};
+    dependencyMocks.execa.mockResolvedValue({stdout: JSON.stringify(metadata)});
+    await expect(getSoundCloudMetadata('https://soundcloud.com/artist/sets/album', 3)).resolves.toEqual(metadata);
+    const args = dependencyMocks.execa.mock.calls[0][1] as string[];
+    expect(args).toEqual(expect.arrayContaining(['--flat-playlist', '--playlist-end', '3']));
+    expect(args).not.toContain('--cookies');
+    expect(dependencyMocks.execa.mock.calls[0][2]).toEqual({timeout: 45_000});
+  });
+
+  it('rejects collection results when resolving an individual SoundCloud audio stream', async () => {
+    dependencyMocks.execa.mockResolvedValue({stdout: JSON.stringify({entries: [], url: 'https://soundcloud.com/artist'})});
+    await expect(getSoundCloudMediaSource('https://soundcloud.com/artist')).rejects.toThrow('playable media URL');
+  });
+
+  it.each([
+    'ERROR: [soundcloud] 123: This video is DRM protected',
+    'ERROR: [soundcloud] artist/removed: Unable to download JSON metadata: HTTP Error 404: Not Found',
+  ])('classifies permanent SoundCloud extraction failure as unplayable: %s', async stderr => {
+    dependencyMocks.execa.mockRejectedValue({stderr});
+    await expect(getSoundCloudMediaSource('https://soundcloud.com/artist/protected'))
+      .rejects.toBeInstanceOf(YtDlpMediaUnavailableError);
+  });
+
+  it('preserves temporary SoundCloud failures for retry', async () => {
+    dependencyMocks.execa.mockRejectedValue({stderr: 'ERROR: [soundcloud] 123: HTTP Error 429: Too Many Requests'});
+    await expect(getSoundCloudMediaSource('https://soundcloud.com/artist/track'))
+      .rejects.not.toBeInstanceOf(YtDlpMediaUnavailableError);
+  });
+
   it('uses the bounded single-video Node-runtime extraction contract and normalizes the selected download', async () => {
     process.env.YT_DLP_PATH = '/fake/yt-dlp';
 
@@ -471,7 +502,10 @@ describe('OPS-11 yt-dlp extraction and ffmpeg handoff', () => {
     });
   });
 
-  it('hands reconnect and CRLF-normalized headers to ffmpeg', async () => {
+  it.each([
+    [MediaSource.Youtube, 'abcdefghijk', 'https://www.youtube.com/watch?v=abcdefghijk'],
+    [MediaSource.SoundCloud, 'https://soundcloud.com/artist/track', 'https://soundcloud.com/artist/track'],
+  ])('hands fresh media and normalized headers to ffmpeg for source %s', async (source, url, extractionUrl) => {
     process.env.YT_DLP_PATH = '/fake/yt-dlp';
     const fileCache = {
       getEntryFor: vi.fn().mockResolvedValue(null),
@@ -480,13 +514,13 @@ describe('OPS-11 yt-dlp extraction and ffmpeg handoff', () => {
     const song: QueuedSong = {
       title: 'Long uncached track',
       artist: 'Artist',
-      url: 'abcdefghijk',
+      url: url as string,
       length: 3_600,
       offset: 0,
       playlist: null,
       isLive: false,
       thumbnailUrl: null,
-      source: MediaSource.Youtube,
+      source: source as MediaSource,
       addedInChannelId: 'text-channel-id',
       requestedBy: 'requester-id',
     };
@@ -497,6 +531,7 @@ describe('OPS-11 yt-dlp extraction and ffmpeg handoff', () => {
     const command = dependencyMocks.ffmpeg.mock.results[0].value as ReturnType<typeof makeFfmpegCommand>;
 
     expect(dependencyMocks.ffmpeg).toHaveBeenCalledWith('https://media.example/requested.webm');
+    expect(dependencyMocks.execa.mock.calls[0][1].at(-1)).toBe(extractionUrl);
     expect(command.inputOptions).toHaveBeenCalledWith([
       '-reconnect',
       '1',

--- a/tests/provider-routing.test.ts
+++ b/tests/provider-routing.test.ts
@@ -4,6 +4,7 @@ import {beforeEach, describe, expect, it, vi} from 'vitest';
 const dependencyMocks = vi.hoisted(() => ({
   ffprobe: vi.fn(),
   shuffle: vi.fn((tracks: unknown[]) => tracks),
+  getSoundCloudMetadata: vi.fn(),
 }));
 
 vi.mock('fluent-ffmpeg', () => ({
@@ -17,11 +18,17 @@ vi.mock('array-shuffle', () => ({
 }));
 
 vi.mock('../src/services/player.js', () => ({
-  MediaSource: {Youtube: 0, HLS: 1},
+  MediaSource: {Youtube: 0, HLS: 1, SoundCloud: 2},
+}));
+
+vi.mock('../src/utils/yt-dlp.js', async importOriginal => ({
+  ...await importOriginal<typeof import('../src/utils/yt-dlp.js')>(),
+  getSoundCloudMetadata: dependencyMocks.getSoundCloudMetadata,
 }));
 
 import GetSongs from '../src/services/get-songs.js';
 import SpotifyAPI from '../src/services/spotify-api.js';
+import {YtDlpMediaUnavailableError} from '../src/utils/yt-dlp.js';
 
 const makeSong = (title: string, url = title.toLowerCase().replaceAll(' ', '-')) => ({
   title,
@@ -62,6 +69,76 @@ beforeEach(() => {
 });
 
 describe('GetSongs provider routing', () => {
+  it.each([
+    'https://soundcloud.com/artist/track',
+    'https://www.soundcloud.com/artist/track',
+    'https://m.soundcloud.com/artist/track',
+    'https://on.soundcloud.com/share-id',
+    'https://snd.sc/share-id',
+  ])('extracts SoundCloud metadata for %s without probing its HTML as audio', async url => {
+    const {getSongs, youtubeAPI} = makeGetSongsHarness();
+    dependencyMocks.getSoundCloudMetadata.mockResolvedValue({
+      title: 'SoundCloud track', uploader: 'Uploader', duration: 181.7,
+      webpage_url: 'https://soundcloud.com/artist/track',
+      url: 'https://media.example/expired-signed-audio', thumbnail: 'https://images.example/art.jpg',
+    });
+
+    await expect(getSongs.getSongs(url, 20, false)).resolves.toEqual([[{
+      title: 'SoundCloud track', artist: 'Uploader', length: 181.7, offset: 0,
+      url, source: 2, isLive: false,
+      playlist: null, thumbnailUrl: 'https://images.example/art.jpg',
+    }], '']);
+    expect(dependencyMocks.getSoundCloudMetadata).toHaveBeenCalledWith(url, 20);
+    expect(dependencyMocks.ffprobe).not.toHaveBeenCalled();
+    expect(youtubeAPI.search).not.toHaveBeenCalled();
+  });
+
+  it('caps SoundCloud playlists in source order and retains page URLs', async () => {
+    const {getSongs} = makeGetSongsHarness();
+    const url = 'https://soundcloud.com/artist/sets/album';
+    dependencyMocks.getSoundCloudMetadata
+      .mockResolvedValueOnce({title: 'Album', entries: [
+        {url: 'https://soundcloud.com/artist/first'},
+        {url: 'https://soundcloud.com/artist/second'},
+      ]})
+      .mockResolvedValueOnce({title: 'First', duration: 100});
+    const [songs] = await getSongs.getSongs(url, 1, false);
+    expect(songs).toEqual([expect.objectContaining({
+      title: 'First', url: 'https://soundcloud.com/artist/first',
+      source: 2, length: 100, playlist: {title: 'Album', source: url},
+    })]);
+    expect(dependencyMocks.getSoundCloudMetadata).toHaveBeenCalledWith(url, 1);
+    expect(dependencyMocks.getSoundCloudMetadata).toHaveBeenCalledWith('https://soundcloud.com/artist/first', 1);
+    expect(dependencyMocks.getSoundCloudMetadata).toHaveBeenCalledTimes(2);
+  });
+
+  it('propagates SoundCloud failures without falling back to ffprobe or a YouTube search', async () => {
+    const {getSongs, youtubeAPI} = makeGetSongsHarness();
+    dependencyMocks.getSoundCloudMetadata.mockRejectedValue(new Error('SoundCloud unavailable'));
+    await expect(getSongs.getSongs('https://soundcloud.com/artist/removed', 20, false))
+      .rejects.toThrow('SoundCloud unavailable');
+    expect(dependencyMocks.ffprobe).not.toHaveBeenCalled();
+    expect(youtubeAPI.search).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    'This video is DRM protected',
+    'ERROR: [soundcloud] artist/removed: Unable to download JSON metadata: HTTP Error 404: Not Found',
+  ])('retains playable SoundCloud playlist entries when another is unavailable: %s', async detail => {
+    const {getSongs} = makeGetSongsHarness();
+    dependencyMocks.getSoundCloudMetadata
+      .mockResolvedValueOnce({title: 'Album', entries: [
+        {url: 'https://soundcloud.com/artist/first'},
+        {url: 'https://soundcloud.com/artist/protected'},
+        {url: 'https://soundcloud.com/artist/last'},
+      ]})
+      .mockResolvedValueOnce({title: 'First', duration: 100})
+      .mockRejectedValueOnce(new YtDlpMediaUnavailableError(detail))
+      .mockResolvedValueOnce({title: 'Last', duration: 200});
+    const [songs] = await getSongs.getSongs('https://soundcloud.com/artist/sets/album', 3, false);
+    expect(songs.map(song => song.title)).toEqual(['First', 'Last']);
+  });
+
   it('uses YouTube search for a free-text query', async () => {
     const {getSongs, youtubeAPI} = makeGetSongsHarness();
     const result = [makeSong('Search result')];


### PR DESCRIPTION
SoundCloud links fell through to the direct-stream provider, so `/play` passed an HTML page to ffprobe and failed before queueing any audio. Route SoundCloud track and share links through yt-dlp, retain the page URL in the queue, and resolve a fresh playable URL when playback starts.

SoundCloud playlists respect the configured limit and resolve their URL-only entries with four concurrent metadata requests, retaining playable entries when another track is unavailable. Playback retains the existing cache, seek, header handling, and Opus startup checks; embeds link back to SoundCloud and bound long queue pages. YouTube cookies remain scoped to YouTube extraction.

Validation: 292 behavior tests, TypeScript checking, lint, build, whitespace checks, and autoreview passed. The candidate image resolved and decoded both a SoundCloud track and a playlist entry into valid Opus audio on the deployment host; playlist fixtures reflect the observed URL-only responses.

- [x] I updated the changelog